### PR TITLE
Deathlink

### DIFF
--- a/worlds/jakanddaxter/Client.py
+++ b/worlds/jakanddaxter/Client.py
@@ -137,7 +137,9 @@ class JakAndDaxterContext(CommonContext):
 
     async def ap_inform_deathlink(self):
         if self.memr.deathlink_enabled:
-            await self.send_death(self.memr.cause_of_death)
+            await self.send_death(self.memr
+                                  .cause_of_death
+                                  .replace("Jak", self.player_names[self.slot]))
 
         # Reset all flags.
         self.memr.send_deathlink = False

--- a/worlds/jakanddaxter/Client.py
+++ b/worlds/jakanddaxter/Client.py
@@ -136,12 +136,12 @@ class JakAndDaxterContext(CommonContext):
         create_task_log_exception(self.ap_inform_finished_game())
 
     async def ap_inform_deathlink(self):
-        if self.memr.send_deathlink:
-            await self.send_death()
+        await self.send_death(self.memr.cause_of_death)
 
-            # Reset all flags.
-            self.memr.send_deathlink = False
-            self.repl.reset_deathlink()
+        # Reset all flags.
+        self.memr.send_deathlink = False
+        self.memr.cause_of_death = ""
+        self.repl.reset_deathlink()
 
     def on_deathlink_check(self):
         create_task_log_exception(self.ap_inform_deathlink())

--- a/worlds/jakanddaxter/Client.py
+++ b/worlds/jakanddaxter/Client.py
@@ -137,9 +137,9 @@ class JakAndDaxterContext(CommonContext):
 
     async def ap_inform_deathlink(self):
         if self.memr.deathlink_enabled:
-            await self.send_death(self.memr
-                                  .cause_of_death
-                                  .replace("Jak", self.player_names[self.slot]))
+            death_text = self.memr.cause_of_death.replace("Jak", self.player_names[self.slot])
+            await self.send_death(death_text)
+            logger.info(death_text)
 
         # Reset all flags.
         self.memr.send_deathlink = False

--- a/worlds/jakanddaxter/client/MemoryReader.py
+++ b/worlds/jakanddaxter/client/MemoryReader.py
@@ -236,7 +236,6 @@ class JakAndDaxterMemoryReader:
             if died > 0:
                 self.send_deathlink = True
                 self.cause_of_death = autopsy(died)
-                logger.info(self.cause_of_death)
 
             deathlink_flag = int.from_bytes(
                 self.gk_process.read_bytes(self.goal_address + deathlink_enabled_offset, sizeof_uint8),

--- a/worlds/jakanddaxter/client/MemoryReader.py
+++ b/worlds/jakanddaxter/client/MemoryReader.py
@@ -1,3 +1,4 @@
+import random
 import typing
 import pymem
 from pymem import pattern
@@ -12,20 +13,52 @@ sizeof_uint64 = 8
 sizeof_uint32 = 4
 sizeof_uint8 = 1
 
-next_cell_index_offset = 0       # Each of these is an uint64, so 8 bytes.
-next_buzzer_index_offset = 8     # Each of these is an uint64, so 8 bytes.
-next_special_index_offset = 16   # Each of these is an uint64, so 8 bytes.
+next_cell_index_offset = 0  # Each of these is an uint64, so 8 bytes.
+next_buzzer_index_offset = 8  # Each of these is an uint64, so 8 bytes.
+next_special_index_offset = 16  # Each of these is an uint64, so 8 bytes.
 
 cells_checked_offset = 24
-buzzers_checked_offset = 428     # cells_checked_offset + (sizeof uint32 * 101 cells)
-specials_checked_offset = 876    # buzzers_checked_offset + (sizeof uint32 * 112 buzzers)
+buzzers_checked_offset = 428  # cells_checked_offset + (sizeof uint32 * 101 cells)
+specials_checked_offset = 876  # buzzers_checked_offset + (sizeof uint32 * 112 buzzers)
 
-buzzers_received_offset = 1004   # specials_checked_offset + (sizeof uint32 * 32 specials)
+buzzers_received_offset = 1004  # specials_checked_offset + (sizeof uint32 * 32 specials)
 specials_received_offset = 1020  # buzzers_received_offset + (sizeof uint8 * 16 levels (for scout fly groups))
 
-died_offset = 1052               # specials_received_offset + (sizeof uint8 * 32 specials)
+died_offset = 1052  # specials_received_offset + (sizeof uint8 * 32 specials)
 
-end_marker_offset = 1053         # died_offset + sizeof uint8
+end_marker_offset = 1053  # died_offset + sizeof uint8
+
+
+def autopsy(died: int) -> str:
+    if died in [1, 2, 3, 4]:
+        return random.choice(["Jak said goodnight.",
+                              "Jak stepped into the light.",
+                              "Jak gave Daxter his insect collection.",
+                              "Jak did not follow Step 1."])
+    if died == 5:
+        return "Jak fell into an endless pit."
+    if died == 6:
+        return "Jak drowned in the green water."
+    if died == 7:
+        return "Jak tried to tackle a Lurker Shark."
+    if died == 8:
+        return "Jak hit 500 degrees."
+    if died == 9:
+        return "Jak took a bath in a pool of dark eco."
+    if died == 10:
+        return "Jak got bombarded with flaming 30-ton boulders."
+    if died == 11:
+        return "Jak hit 800 degrees."
+    if died == 12:
+        return "Jak ceased to be."
+    if died == 13:
+        return "Jak got eaten by the dark eco plant."
+    if died == 14:
+        return "Jak burned up."
+    if died == 15:
+        return "Jak hit the ground hard."
+
+    return "Jak died."
 
 
 class JakAndDaxterMemoryReader:
@@ -41,6 +74,7 @@ class JakAndDaxterMemoryReader:
     outbox_index = 0
     finished_game = False
     send_deathlink = False
+    cause_of_death = ""
 
     def __init__(self, marker: typing.ByteString = b'UnLiStEdStRaTs_JaK1\x00'):
         self.marker = marker
@@ -178,9 +212,10 @@ class JakAndDaxterMemoryReader:
                 byteorder="little",
                 signed=False)
 
-            if died == 1:
+            if died > 0:
                 self.send_deathlink = True
-                logger.debug("You Died!")
+                self.cause_of_death = autopsy(died)
+                logger.info(self.cause_of_death)
 
         except (ProcessError, MemoryReadError, WinAPIError):
             logger.error("The gk process has died. Restart the game and run \"/memr connect\" again.")

--- a/worlds/jakanddaxter/client/MemoryReader.py
+++ b/worlds/jakanddaxter/client/MemoryReader.py
@@ -31,7 +31,9 @@ deathlink_enabled_offset = 1053  # died_offset + sizeof uint8
 end_marker_offset = 1054  # deathlink_enabled_offset + sizeof uint8
 
 
+# "Jak" to be replaced by player name in the Client.
 def autopsy(died: int) -> str:
+    assert died > 0, f"Tried to find Jak's cause of death, but he's still alive!"
     if died in [1, 2, 3, 4]:
         return random.choice(["Jak said goodnight.",
                               "Jak stepped into the light.",
@@ -59,6 +61,12 @@ def autopsy(died: int) -> str:
         return "Jak burned up."
     if died == 15:
         return "Jak hit the ground hard."
+    if died == 16:
+        return "Jak crashed the zoomer."
+    if died == 17:
+        return "Jak got Flut Flut hurt."
+    if died == 18:
+        return "Jak poisoned the whole darn catch."
 
     return "Jak died."
 

--- a/worlds/jakanddaxter/client/ReplClient.py
+++ b/worlds/jakanddaxter/client/ReplClient.py
@@ -250,15 +250,7 @@ class JakAndDaxterReplClient:
                        "\'dark-eco-pool"]
         chosen_death = random.choice(death_types)
 
-        ok = self.send_form("(send-event "
-                            "*target* \'attack #f "
-                            "(static-attack-info "
-                            "  ((deathlink-death #t) "
-                            "  (mode " + chosen_death + ") "
-                            "  (vector (new \'static \'vector :y (meters 1) :w 1.0)) "
-                            "  (angle \'up) "
-                            "  (control 1.0))))")
-
+        ok = self.send_form("(ap-deathlink-received! " + chosen_death + ")")
         if ok:
             logger.debug(f"Received deathlink signal!")
         else:

--- a/worlds/jakanddaxter/client/ReplClient.py
+++ b/worlds/jakanddaxter/client/ReplClient.py
@@ -239,16 +239,26 @@ class JakAndDaxterReplClient:
 
     def receive_deathlink(self) -> bool:
 
-        # Because it should at least be funny.
-        death_types = ["\'endlessfall",
-                       "\'drown-death",
+        # Because it should at least be funny sometimes.
+        death_types = ["\'death",
                        "\'death",
+                       "\'death",
+                       "\'death",
+                       "\'endlessfall",
+                       "\'drown-death",
                        "\'melt",
                        "\'dark-eco-pool"]
         chosen_death = random.choice(death_types)
 
-        ok = self.send_form("(when (not (movie?)) "
-                            "(target-attack-up *target* \'attack " + chosen_death + "))")
+        ok = self.send_form("(send-event "
+                            "*target* \'attack #f "
+                            "(static-attack-info "
+                            "  ((deathlink-death #t) "
+                            "  (mode " + chosen_death + ") "
+                            "  (vector (new \'static \'vector :y (meters 1) :w 1.0)) "
+                            "  (angle \'up) "
+                            "  (control 1.0))))")
+
         if ok:
             logger.debug(f"Received deathlink signal!")
         else:

--- a/worlds/jakanddaxter/client/ReplClient.py
+++ b/worlds/jakanddaxter/client/ReplClient.py
@@ -2,6 +2,7 @@ import json
 import time
 import struct
 import typing
+import random
 from socket import socket, AF_INET, SOCK_STREAM
 
 import pymem
@@ -24,6 +25,7 @@ class JakAndDaxterReplClient:
     sock: socket
     connected: bool = False
     initiated_connect: bool = False  # Signals when user tells us to try reconnecting.
+    received_deathlink: bool = False
 
     # The REPL client needs the REPL/compiler process running, but that process
     # also needs the game running. Therefore, the REPL client needs both running.
@@ -61,6 +63,14 @@ class JakAndDaxterReplClient:
         if len(self.item_inbox) > self.inbox_index:
             self.receive_item()
             self.inbox_index += 1
+
+        if self.received_deathlink:
+            self.receive_deathlink()
+
+            # Reset all flags.
+            # Even a received deathlink will set our own deathlink flag, we should reset it immediately.
+            self.reset_deathlink()
+            self.received_deathlink = False
 
     # This helper function formats and sends `form` as a command to the REPL.
     # ALL commands to the REPL should be sent using this function.
@@ -225,6 +235,32 @@ class JakAndDaxterReplClient:
             logger.debug(f"Received special unlock {item_table[ap_id]}!")
         else:
             logger.error(f"Unable to receive special unlock {item_table[ap_id]}!")
+        return ok
+
+    def receive_deathlink(self) -> bool:
+
+        # Because it should at least be funny.
+        death_types = ["\'endlessfall",
+                       "\'drown-death",
+                       "\'death",
+                       "\'melt",
+                       "\'dark-eco-pool"]
+        chosen_death = random.choice(death_types)
+
+        ok = self.send_form("(when (not (movie?)) "
+                            "(target-attack-up *target* \'attack " + chosen_death + "))")
+        if ok:
+            logger.debug(f"Received deathlink signal!")
+        else:
+            logger.error(f"Unable to receive deathlink signal!")
+        return ok
+
+    def reset_deathlink(self) -> bool:
+        ok = self.send_form("(set! (-> *ap-info-jak1 died) 0)")
+        if ok:
+            logger.debug(f"Reset deathlink flag!")
+        else:
+            logger.error(f"Unable to reset deathlink flag!")
         return ok
 
     def save_data(self):

--- a/worlds/jakanddaxter/client/ReplClient.py
+++ b/worlds/jakanddaxter/client/ReplClient.py
@@ -68,7 +68,7 @@ class JakAndDaxterReplClient:
             self.receive_deathlink()
 
             # Reset all flags.
-            # Even a received deathlink will set our own deathlink flag, we should reset it immediately.
+            # As a precaution, we should reset our own deathlink flag as well.
             self.reset_deathlink()
             self.received_deathlink = False
 
@@ -266,7 +266,7 @@ class JakAndDaxterReplClient:
         return ok
 
     def reset_deathlink(self) -> bool:
-        ok = self.send_form("(set! (-> *ap-info-jak1 died) 0)")
+        ok = self.send_form("(set! (-> *ap-info-jak1* died) 0)")
         if ok:
             logger.debug(f"Reset deathlink flag!")
         else:


### PR DESCRIPTION
## What is this fixing or adding?
### Deathlink Added
Deathlink signals are sent when:
- Jak dies while on foot, on Flut Flut, or on the Zoomer.
- Jak catches a poison eel during the fishing minigame.
- Jak is eaten by the plant boss or lurker shark.

When Deathlink signals are received:
- If Jak is in a cutscene, the signal is swallowed and he will live.
- If Jak is in the fishing minigame, he will immediately fail the minigame.
- If Jak is on foot, on Flut Flut, or on the Zoomer, he will die in a random way.

### In-game Settings Added
Deathlink is toggleable at any time during gameplay through the Archipelago Options menu. This setting is saved to, and loaded from, a *.GC file in the ArchipelaGOAL mod folder. This may serve as the foundation for future optional features.

### Potential fix to incorrect Scout Fly counts added.

### Translations Added
- Swedish, by Level70
- Danish, by Jacobmix
- German, by Abbacchio
- French, by Troyoo

## How was this tested?
Played a multi-world seed with Jak and Noita. Had Jak die while on foot, on Flut Flut, on the Zoomer, and catching a poison eel during the fishing minigame. All scenarios send out the Deathlink flag to Noita, along with the properly formatted death text. Had Noita die while Jak was on foot, on Flut Flut, on the Zoomer, and playing the fishing minigame. All scenarios saw Jak die in a random way (with some limited animation options for Flut Flut and Zoomer) (and fishing minigame triggered an instant failure) (unlike fishing minigame, Jak dies normally during Billy's rat minigame with no special code required).

## If this makes graphical changes, please attach screenshots.
![image](https://github.com/ArchipelaGOAL/Archipelago/assets/8584296/8ea3de15-3dfc-405f-b1c9-b9044006ae37)
![image](https://github.com/ArchipelaGOAL/Archipelago/assets/8584296/88134e4c-70d4-4676-8389-68ed4408dcd8)




