### PR TITLE
Orbsanity

### DIFF
--- a/worlds/jakanddaxter/Client.py
+++ b/worlds/jakanddaxter/Client.py
@@ -147,7 +147,8 @@ class JakAndDaxterContext(CommonContext):
 
     async def ap_inform_deathlink(self):
         if self.memr.deathlink_enabled:
-            death_text = self.memr.cause_of_death.replace("Jak", self.player_names[self.slot])
+            player = self.player_names[self.slot] if self.slot is not None else "Jak"
+            death_text = self.memr.cause_of_death.replace("Jak", player)
             await self.send_death(death_text)
             logger.info(death_text)
 

--- a/worlds/jakanddaxter/Client.py
+++ b/worlds/jakanddaxter/Client.py
@@ -114,6 +114,8 @@ class JakAndDaxterContext(CommonContext):
                 self.repl.setup_orbsanity(slot_data["enable_orbsanity"], slot_data["level_orbsanity_bundle_size"])
             elif slot_data["enable_orbsanity"] == 2:
                 self.repl.setup_orbsanity(slot_data["enable_orbsanity"], slot_data["global_orbsanity_bundle_size"])
+            else:
+                self.repl.setup_orbsanity(slot_data["enable_orbsanity"], 1)
 
         if cmd == "ReceivedItems":
             for index, item in enumerate(args["items"], start=args["index"]):

--- a/worlds/jakanddaxter/Client.py
+++ b/worlds/jakanddaxter/Client.py
@@ -107,6 +107,14 @@ class JakAndDaxterContext(CommonContext):
         await self.send_connect()
 
     def on_package(self, cmd: str, args: dict):
+
+        if cmd == "Connected":
+            slot_data = args["slot_data"]
+            if slot_data["enable_orbsanity"] == 1:
+                self.repl.setup_orbsanity(slot_data["enable_orbsanity"], slot_data["level_orbsanity_bundle_size"])
+            elif slot_data["enable_orbsanity"] == 2:
+                self.repl.setup_orbsanity(slot_data["enable_orbsanity"], slot_data["global_orbsanity_bundle_size"])
+
         if cmd == "ReceivedItems":
             for index, item in enumerate(args["items"], start=args["index"]):
                 logger.debug(f"index: {str(index)}, item: {str(item)}")
@@ -155,6 +163,14 @@ class JakAndDaxterContext(CommonContext):
     def on_deathlink_toggle(self):
         create_task_log_exception(self.ap_inform_deathlink_toggle())
 
+    async def repl_reset_orbsanity(self):
+        if self.memr.orbsanity_enabled:
+            self.memr.reset_orbsanity = False
+            self.repl.reset_orbsanity()
+
+    def on_orbsanity_check(self):
+        create_task_log_exception(self.repl_reset_orbsanity())
+
     async def run_repl_loop(self):
         while True:
             await self.repl.main_tick()
@@ -165,7 +181,8 @@ class JakAndDaxterContext(CommonContext):
             await self.memr.main_tick(self.on_location_check,
                                       self.on_finish_check,
                                       self.on_deathlink_check,
-                                      self.on_deathlink_toggle)
+                                      self.on_deathlink_toggle,
+                                      self.on_orbsanity_check)
             await asyncio.sleep(0.1)
 
 

--- a/worlds/jakanddaxter/Items.py
+++ b/worlds/jakanddaxter/Items.py
@@ -39,7 +39,8 @@ scout_item_table = {
 }
 
 # Orbs are also generic and interchangeable.
-# These items are only used by Orbsanity, and only one of these items will be used corresponding to the chosen value.
+# These items are only used by Orbsanity, and only one of these
+# items will be used corresponding to the chosen bundle size.
 orb_item_table = {
     1: "Precursor Orb",
     2: "Bundle of 2 Precursor Orbs",

--- a/worlds/jakanddaxter/Items.py
+++ b/worlds/jakanddaxter/Items.py
@@ -40,7 +40,7 @@ scout_item_table = {
 
 # Orbs are also generic and interchangeable.
 orb_item_table = {
-    1: "Precursor Orb",
+    1: "A Bundle of X Precursor Orbs",
 }
 
 # These are special items representing unique unlocks in the world. Notice that their Item ID equals their

--- a/worlds/jakanddaxter/Items.py
+++ b/worlds/jakanddaxter/Items.py
@@ -85,8 +85,8 @@ move_item_table = {
 item_table = {
     **{Cells.to_ap_id(k): cell_item_table[k] for k in cell_item_table},
     **{Scouts.to_ap_id(k): scout_item_table[k] for k in scout_item_table},
-    **{Orbs.to_ap_id(k): orb_item_table[k] for k in orb_item_table},
     **{Specials.to_ap_id(k): special_item_table[k] for k in special_item_table},
     **{Caches.to_ap_id(k): move_item_table[k] for k in move_item_table},
+    **{Orbs.to_ap_id(k): orb_item_table[k] for k in orb_item_table},
     jak1_max: "Green Eco Pill"  # Filler item.
 }

--- a/worlds/jakanddaxter/Items.py
+++ b/worlds/jakanddaxter/Items.py
@@ -39,8 +39,28 @@ scout_item_table = {
 }
 
 # Orbs are also generic and interchangeable.
+# These items are only used by Orbsanity, and only one of these items will be used corresponding to the chosen value.
 orb_item_table = {
-    1: "A Bundle of X Precursor Orbs",
+    1: "Precursor Orb",
+    2: "Bundle of 2 Precursor Orbs",
+    4: "Bundle of 4 Precursor Orbs",
+    5: "Bundle of 5 Precursor Orbs",
+    8: "Bundle of 8 Precursor Orbs",
+    10: "Bundle of 10 Precursor Orbs",
+    16: "Bundle of 16 Precursor Orbs",
+    20: "Bundle of 20 Precursor Orbs",
+    25: "Bundle of 25 Precursor Orbs",
+    40: "Bundle of 40 Precursor Orbs",
+    50: "Bundle of 50 Precursor Orbs",
+    80: "Bundle of 80 Precursor Orbs",
+    100: "Bundle of 100 Precursor Orbs",
+    125: "Bundle of 125 Precursor Orbs",
+    200: "Bundle of 200 Precursor Orbs",
+    250: "Bundle of 250 Precursor Orbs",
+    400: "Bundle of 400 Precursor Orbs",
+    500: "Bundle of 500 Precursor Orbs",
+    1000: "Bundle of 1000 Precursor Orbs",
+    2000: "Bundle of 2000 Precursor Orbs",
 }
 
 # These are special items representing unique unlocks in the world. Notice that their Item ID equals their

--- a/worlds/jakanddaxter/JakAndDaxterOptions.py
+++ b/worlds/jakanddaxter/JakAndDaxterOptions.py
@@ -10,14 +10,14 @@ class EnableMoveRandomizer(Toggle):
     display_name = "Enable Move Randomizer"
 
 
-# class EnableOrbsanity(Toggle):
-#     """Enable to include Precursor Orbs as an ordered list of progressive checks.
-#     Each orb you collect triggers the next release in the list.
-#     Adds 2000 items to the pool."""
-#     display_name = "Enable Orbsanity"
+class EnableOrbsanity(Toggle):
+    """Enable to include Precursor Orbs as an ordered list of progressive checks.
+    Each orb you collect triggers the next release in the list.
+    Adds 2000 items to the pool."""
+    display_name = "Enable Orbsanity"
 
 
 @dataclass
 class JakAndDaxterOptions(PerGameCommonOptions):
     enable_move_randomizer: EnableMoveRandomizer
-    # enable_orbsanity: EnableOrbsanity
+    enable_orbsanity: EnableOrbsanity

--- a/worlds/jakanddaxter/JakAndDaxterOptions.py
+++ b/worlds/jakanddaxter/JakAndDaxterOptions.py
@@ -3,21 +3,32 @@ from Options import Toggle, PerGameCommonOptions, Choice
 
 
 class EnableMoveRandomizer(Toggle):
-    """Enable to include movement options as items in the randomizer.
-    Jak is only able to run, swim, and single jump, until you find his other moves.
-    This adds 11 items to the pool."""
+    """Enable to include movement options as items in the randomizer. Jak is only able to run, swim, and single jump,
+    until you find his other moves. This adds 11 items to the pool."""
     display_name = "Enable Move Randomizer"
 
 
 class EnableOrbsanity(Choice):
-    """Enable to include bundles of Precursor Orb as an ordered list of progressive checks.
-    Every time you collect the chosen number of orbs, you will trigger the next release in the list.
+    """Enable to include bundles of Precursor Orb as an ordered list of progressive checks. Every time you collect
+    the chosen number of orbs, you will trigger the next release in the list. "Per Level" means these lists are
+    generated and populated for each level in the game (Geyser Rock, Sandover Village, etc.). "Global" means there is
+    only one list for the entire game.
 
     This adds a number of Items and Locations to the pool inversely proportional to the size of the bundle.
     For example, if your bundle size is 20 orbs, you will add 100 items to the pool. If your bundle size is 250 orbs,
-    you will add 8 items to the pool. There are 2000 orbs in the game, so your bundle size must be a factor of 2000."""
+    you will add 8 items to the pool."""
     display_name = "Enable Orbsanity"
     option_off = 0
+    option_per_level = 1
+    option_global = 2
+    default = 0
+
+
+class GlobalOrbsanityBundleSize(Choice):
+    """Set the size of the bundle for Global Orbsanity.
+    This only applies if "Enable Orbsanity" is set to "Global."
+    There are 2000 orbs in the game, so your bundle size must be a factor of 2000."""
+    display_name = "Global Orbsanity Bundle Size"
     option_1_orb = 1
     option_2_orbs = 2
     option_4_orbs = 4
@@ -38,10 +49,26 @@ class EnableOrbsanity(Choice):
     option_500_orbs = 500
     option_1000_orbs = 1000
     option_2000_orbs = 2000
-    default = 0
+    default = 1
+
+
+class PerLevelOrbsanityBundleSize(Choice):
+    """Set the size of the bundle for Per Level Orbsanity.
+    This only applies if "Enable Orbsanity" is set to "Per Level."
+    There are 50, 150, or 200 orbs per level, so your bundle size must be a factor of 50."""
+    display_name = "Per Level Orbsanity Bundle Size"
+    option_1_orb = 1
+    option_2_orbs = 2
+    option_5_orbs = 5
+    option_10_orbs = 10
+    option_25_orbs = 25
+    option_50_orbs = 50
+    default = 1
 
 
 @dataclass
 class JakAndDaxterOptions(PerGameCommonOptions):
     enable_move_randomizer: EnableMoveRandomizer
     enable_orbsanity: EnableOrbsanity
+    global_orbsanity_bundle_size = GlobalOrbsanityBundleSize
+    level_orbsanity_bundle_size = PerLevelOrbsanityBundleSize

--- a/worlds/jakanddaxter/JakAndDaxterOptions.py
+++ b/worlds/jakanddaxter/JakAndDaxterOptions.py
@@ -1,4 +1,3 @@
-import os
 from dataclasses import dataclass
 from Options import Toggle, PerGameCommonOptions, Choice
 
@@ -22,6 +21,7 @@ class EnableOrbsanity(Choice):
     option_1_orb = 1
     option_2_orbs = 2
     option_4_orbs = 4
+    option_5_orbs = 5
     option_8_orbs = 8
     option_10_orbs = 10
     option_16_orbs = 16
@@ -34,6 +34,7 @@ class EnableOrbsanity(Choice):
     option_125_orbs = 125
     option_200_orbs = 200
     option_250_orbs = 250
+    option_400_orbs = 400
     option_500_orbs = 500
     option_1000_orbs = 1000
     option_2000_orbs = 2000

--- a/worlds/jakanddaxter/JakAndDaxterOptions.py
+++ b/worlds/jakanddaxter/JakAndDaxterOptions.py
@@ -9,7 +9,7 @@ class EnableMoveRandomizer(Toggle):
 
 
 class EnableOrbsanity(Choice):
-    """Enable to include bundles of Precursor Orb as an ordered list of progressive checks. Every time you collect
+    """Enable to include bundles of Precursor Orbs as an ordered list of progressive checks. Every time you collect
     the chosen number of orbs, you will trigger the next release in the list. "Per Level" means these lists are
     generated and populated for each level in the game (Geyser Rock, Sandover Village, etc.). "Global" means there is
     only one list for the entire game.
@@ -70,5 +70,5 @@ class PerLevelOrbsanityBundleSize(Choice):
 class JakAndDaxterOptions(PerGameCommonOptions):
     enable_move_randomizer: EnableMoveRandomizer
     enable_orbsanity: EnableOrbsanity
-    global_orbsanity_bundle_size = GlobalOrbsanityBundleSize
-    level_orbsanity_bundle_size = PerLevelOrbsanityBundleSize
+    global_orbsanity_bundle_size: GlobalOrbsanityBundleSize
+    level_orbsanity_bundle_size: PerLevelOrbsanityBundleSize

--- a/worlds/jakanddaxter/JakAndDaxterOptions.py
+++ b/worlds/jakanddaxter/JakAndDaxterOptions.py
@@ -1,20 +1,43 @@
 import os
 from dataclasses import dataclass
-from Options import Toggle, PerGameCommonOptions
+from Options import Toggle, PerGameCommonOptions, Choice
 
 
 class EnableMoveRandomizer(Toggle):
     """Enable to include movement options as items in the randomizer.
     Jak is only able to run, swim, and single jump, until you find his other moves.
-    Adds 11 items to the pool."""
+    This adds 11 items to the pool."""
     display_name = "Enable Move Randomizer"
 
 
-class EnableOrbsanity(Toggle):
-    """Enable to include Precursor Orbs as an ordered list of progressive checks.
-    Each orb you collect triggers the next release in the list.
-    Adds 2000 items to the pool."""
+class EnableOrbsanity(Choice):
+    """Enable to include bundles of Precursor Orb as an ordered list of progressive checks.
+    Every time you collect the chosen number of orbs, you will trigger the next release in the list.
+
+    This adds a number of Items and Locations to the pool inversely proportional to the size of the bundle.
+    For example, if your bundle size is 20 orbs, you will add 100 items to the pool. If your bundle size is 250 orbs,
+    you will add 8 items to the pool. There are 2000 orbs in the game, so your bundle size must be a factor of 2000."""
     display_name = "Enable Orbsanity"
+    option_off = 0
+    option_1_orb = 1
+    option_2_orbs = 2
+    option_4_orbs = 4
+    option_8_orbs = 8
+    option_10_orbs = 10
+    option_16_orbs = 16
+    option_20_orbs = 20
+    option_25_orbs = 25
+    option_40_orbs = 40
+    option_50_orbs = 50
+    option_80_orbs = 80
+    option_100_orbs = 100
+    option_125_orbs = 125
+    option_200_orbs = 200
+    option_250_orbs = 250
+    option_500_orbs = 500
+    option_1000_orbs = 1000
+    option_2000_orbs = 2000
+    default = 0
 
 
 @dataclass

--- a/worlds/jakanddaxter/Locations.py
+++ b/worlds/jakanddaxter/Locations.py
@@ -49,5 +49,4 @@ location_table = {
     **{Scouts.to_ap_id(k): Scouts.locGMC_scoutTable[k] for k in Scouts.locGMC_scoutTable},
     **{Specials.to_ap_id(k): Specials.loc_specialTable[k] for k in Specials.loc_specialTable},
     **{Caches.to_ap_id(k): Caches.loc_orbCacheTable[k] for k in Caches.loc_orbCacheTable},
-    **{Orbs.to_ap_id(k): Orbs.loc_orbTable[k] for k in Orbs.loc_orbTable},
 }

--- a/worlds/jakanddaxter/Locations.py
+++ b/worlds/jakanddaxter/Locations.py
@@ -1,6 +1,7 @@
 from BaseClasses import Location
 from .GameID import jak1_name
-from .locs import (CellLocations as Cells,
+from .locs import (OrbLocations as Orbs,
+                   CellLocations as Cells,
                    ScoutLocations as Scouts,
                    SpecialLocations as Specials,
                    OrbCacheLocations as Caches)
@@ -48,4 +49,5 @@ location_table = {
     **{Scouts.to_ap_id(k): Scouts.locGMC_scoutTable[k] for k in Scouts.locGMC_scoutTable},
     **{Specials.to_ap_id(k): Specials.loc_specialTable[k] for k in Specials.loc_specialTable},
     **{Caches.to_ap_id(k): Caches.loc_orbCacheTable[k] for k in Caches.loc_orbCacheTable},
+    **{Orbs.to_ap_id(k): Orbs.loc_orbTable[k] for k in Orbs.loc_orbTable},
 }

--- a/worlds/jakanddaxter/Locations.py
+++ b/worlds/jakanddaxter/Locations.py
@@ -49,4 +49,5 @@ location_table = {
     **{Scouts.to_ap_id(k): Scouts.locGMC_scoutTable[k] for k in Scouts.locGMC_scoutTable},
     **{Specials.to_ap_id(k): Specials.loc_specialTable[k] for k in Specials.loc_specialTable},
     **{Caches.to_ap_id(k): Caches.loc_orbCacheTable[k] for k in Caches.loc_orbCacheTable},
+    **{Orbs.to_ap_id(k): Orbs.loc_orbBundleTable[k] for k in Orbs.loc_orbBundleTable}
 }

--- a/worlds/jakanddaxter/Regions.py
+++ b/worlds/jakanddaxter/Regions.py
@@ -51,8 +51,8 @@ def create_regions(multiworld: MultiWorld, options: JakAndDaxterOptions, player:
         bundle_count = int(2000 / bundle_size)
         for bundle_index in range(bundle_count):
 
-            # Unlike Per-Level Orbsanity, Global Orbsanity Locations always have a level_index of 0.
-            orbs.add_orb_locations(0,
+            # Unlike Per-Level Orbsanity, Global Orbsanity Locations always have a level_index of 16.
+            orbs.add_orb_locations(16,
                                    bundle_index,
                                    bundle_size,
                                    access_rule=lambda state, bundle=bundle_index:

--- a/worlds/jakanddaxter/Regions.py
+++ b/worlds/jakanddaxter/Regions.py
@@ -50,7 +50,7 @@ def create_regions(multiworld: MultiWorld, options: JakAndDaxterOptions, player:
         bundle_size = options.global_orbsanity_bundle_size.value
         bundle_count = int(2000 / bundle_size)
         for bundle_id in range(bundle_count):
-            orbs.add_orb_locations([bundle_id], access_rule=lambda state, bundle=bundle_id:
+            orbs.add_orb_locations(bundle_id, access_rule=lambda state, bundle=bundle_id:
                                    can_reach_orbs(state, player, multiworld, options) >= (bundle_size * (bundle + 1)))
         multiworld.regions.append(orbs)
         menu.connect(orbs)

--- a/worlds/jakanddaxter/Regions.py
+++ b/worlds/jakanddaxter/Regions.py
@@ -49,9 +49,15 @@ def create_regions(multiworld: MultiWorld, options: JakAndDaxterOptions, player:
 
         bundle_size = options.global_orbsanity_bundle_size.value
         bundle_count = int(2000 / bundle_size)
-        for bundle_id in range(bundle_count):
-            orbs.add_orb_locations(bundle_id, access_rule=lambda state, bundle=bundle_id:
-                                   can_reach_orbs(state, player, multiworld, options) >= (bundle_size * (bundle + 1)))
+        for bundle_index in range(bundle_count):
+
+            # Unlike Per-Level Orbsanity, Global Orbsanity Locations always have a level_index of 0.
+            orbs.add_orb_locations(0,
+                                   bundle_index,
+                                   bundle_size,
+                                   access_rule=lambda state, bundle=bundle_index:
+                                   can_reach_orbs(state, player, multiworld, options)
+                                   >= (bundle_size * (bundle + 1)))
         multiworld.regions.append(orbs)
         menu.connect(orbs)
 

--- a/worlds/jakanddaxter/Regions.py
+++ b/worlds/jakanddaxter/Regions.py
@@ -49,31 +49,30 @@ def create_regions(multiworld: MultiWorld, options: JakAndDaxterOptions, player:
 
         # We already made sure bundle_size is not 0. No division error here!
         bundle_size = options.enable_orbsanity.value
-        num_bundles = 2000 / bundle_size
-
-        for bundle_id in range(int(num_bundles)):
+        bundle_count = int(2000 / bundle_size)
+        for bundle_id in range(bundle_count):
             orbs.add_orb_locations([bundle_id], access_rule=lambda state, bundle=bundle_id:
-                                   can_reach_orbs(state, player, multiworld, (bundle_size * (bundle + 1))))
+                                   can_reach_orbs(state, player, multiworld) >= (bundle_size * (bundle + 1)))
         multiworld.regions.append(orbs)
         menu.connect(orbs)
 
     # Build all regions. Include their intra-connecting Rules, their Locations, and their Location access rules.
-    [gr] = GeyserRock.build_regions("Geyser Rock", player, multiworld)
-    [sv] = SandoverVillage.build_regions("Sandover Village", player, multiworld)
-    [fj] = ForbiddenJungle.build_regions("Forbidden Jungle", player, multiworld)
-    [sb] = SentinelBeach.build_regions("Sentinel Beach", player, multiworld)
-    [mi] = MistyIsland.build_regions("Misty Island", player, multiworld)
-    [fc] = FireCanyon.build_regions("Fire Canyon", player, multiworld)
-    [rv, rvp, rvc] = RockVillage.build_regions("Rock Village", player, multiworld)
-    [pb] = PrecursorBasin.build_regions("Precursor Basin", player, multiworld)
-    [lpc] = LostPrecursorCity.build_regions("Lost Precursor City", player, multiworld)
-    [bs] = BoggySwamp.build_regions("Boggy Swamp", player, multiworld)
-    [mp, mpr] = MountainPass.build_regions("Mountain Pass", player, multiworld)
-    [vc] = VolcanicCrater.build_regions("Volcanic Crater", player, multiworld)
-    [sc] = SpiderCave.build_regions("Spider Cave", player, multiworld)
-    [sm] = SnowyMountain.build_regions("Snowy Mountain", player, multiworld)
-    [lt] = LavaTube.build_regions("Lava Tube", player, multiworld)
-    [gmc, fb] = GolAndMaiasCitadel.build_regions("Gol and Maia's Citadel", player, multiworld)
+    [gr] = GeyserRock.build_regions("Geyser Rock", multiworld, options, player)
+    [sv] = SandoverVillage.build_regions("Sandover Village", multiworld, options, player)
+    [fj] = ForbiddenJungle.build_regions("Forbidden Jungle", multiworld, options, player)
+    [sb] = SentinelBeach.build_regions("Sentinel Beach", multiworld, options, player)
+    [mi] = MistyIsland.build_regions("Misty Island", multiworld, options, player)
+    [fc] = FireCanyon.build_regions("Fire Canyon", multiworld, options, player)
+    [rv, rvp, rvc] = RockVillage.build_regions("Rock Village", multiworld, options, player)
+    [pb] = PrecursorBasin.build_regions("Precursor Basin", multiworld, options, player)
+    [lpc] = LostPrecursorCity.build_regions("Lost Precursor City", multiworld, options, player)
+    [bs] = BoggySwamp.build_regions("Boggy Swamp", multiworld, options, player)
+    [mp, mpr] = MountainPass.build_regions("Mountain Pass", multiworld, options, player)
+    [vc] = VolcanicCrater.build_regions("Volcanic Crater", multiworld, options, player)
+    [sc] = SpiderCave.build_regions("Spider Cave", multiworld, options, player)
+    [sm] = SnowyMountain.build_regions("Snowy Mountain", multiworld, options, player)
+    [lt] = LavaTube.build_regions("Lava Tube", multiworld, options, player)
+    [gmc, fb] = GolAndMaiasCitadel.build_regions("Gol and Maia's Citadel", multiworld, options, player)
 
     # Define the interconnecting rules.
     menu.connect(gr)

--- a/worlds/jakanddaxter/Regions.py
+++ b/worlds/jakanddaxter/Regions.py
@@ -42,17 +42,16 @@ def create_regions(multiworld: MultiWorld, options: JakAndDaxterOptions, player:
     multiworld.regions.append(free7)
     menu.connect(free7)
 
-    # If Orbsanity is enabled, build the special Orbsanity Region. This is a virtual region always accessible to Menu.
-    # The Locations within are automatically checked when you collect an orb.
-    if options.enable_orbsanity.value > 0:
+    # If Global Orbsanity is enabled, build the special Orbsanity Region. This is a virtual region always
+    # accessible to Menu. The Locations within are automatically checked when you collect enough orbs.
+    if options.enable_orbsanity.value == 2:
         orbs = JakAndDaxterRegion("Orbsanity", player, multiworld)
 
-        # We already made sure bundle_size is not 0. No division error here!
-        bundle_size = options.enable_orbsanity.value
+        bundle_size = options.global_orbsanity_bundle_size.value
         bundle_count = int(2000 / bundle_size)
         for bundle_id in range(bundle_count):
             orbs.add_orb_locations([bundle_id], access_rule=lambda state, bundle=bundle_id:
-                                   can_reach_orbs(state, player, multiworld) >= (bundle_size * (bundle + 1)))
+                                   can_reach_orbs(state, player, multiworld, options) >= (bundle_size * (bundle + 1)))
         multiworld.regions.append(orbs)
         menu.connect(orbs)
 

--- a/worlds/jakanddaxter/Regions.py
+++ b/worlds/jakanddaxter/Regions.py
@@ -1,7 +1,7 @@
 from BaseClasses import MultiWorld
 from .JakAndDaxterOptions import JakAndDaxterOptions
 from .Items import item_table
-from .Rules import can_trade, can_reach_orb
+from .Rules import can_reach_orbs
 from .locs import (OrbLocations as Orbs,
                    CellLocations as Cells,
                    ScoutLocations as Scouts)
@@ -44,12 +44,16 @@ def create_regions(multiworld: MultiWorld, options: JakAndDaxterOptions, player:
 
     # If Orbsanity is enabled, build the special Orbsanity Region. This is a virtual region always accessible to Menu.
     # The Locations within are automatically checked when you collect an orb.
-    if options.enable_orbsanity:
+    if options.enable_orbsanity.value > 0:
         orbs = JakAndDaxterRegion("Orbsanity", player, multiworld)
 
-        for orb_id in Orbs.loc_orbTable:
-            orbs.add_orb_locations([orb_id], access_rule=lambda state, orb=orb_id:
-                                   can_reach_orb(state, player, multiworld, orb))
+        # We already made sure bundle_size is not 0. No division error here!
+        bundle_size = options.enable_orbsanity.value
+        num_bundles = 2000 / bundle_size
+
+        for bundle_id in range(int(num_bundles)):
+            orbs.add_orb_locations([bundle_id], access_rule=lambda state, bundle=bundle_id:
+                                   can_reach_orbs(state, player, multiworld, (bundle_size * (bundle + 1))))
         multiworld.regions.append(orbs)
         menu.connect(orbs)
 

--- a/worlds/jakanddaxter/Rules.py
+++ b/worlds/jakanddaxter/Rules.py
@@ -3,19 +3,47 @@ import typing
 from BaseClasses import MultiWorld, CollectionState
 from .JakAndDaxterOptions import JakAndDaxterOptions
 from .Items import orb_item_table
-from .locs import CellLocations as Cells, OrbLocations as Orbs
+from .locs import CellLocations as Cells
 from .Locations import location_table
 from .regs.RegionBase import JakAndDaxterRegion
 
 
 def can_reach_orbs(state: CollectionState,
                    player: int,
-                   multiworld: MultiWorld) -> int:
+                   multiworld: MultiWorld,
+                   options: JakAndDaxterOptions,
+                   level_name: str = None) -> int:
+
+    # Global Orbsanity and No Orbsanity both treat orbs as completely interchangeable.
+    # Per Level Orbsanity needs to know if you can reach orbs *in a particular level.*
+    if options.enable_orbsanity.value in [0, 2]:
+        return can_reach_orbs_global(state, player, multiworld)
+    else:
+        return can_reach_orbs_level(state, player, multiworld, level_name)
+
+
+def can_reach_orbs_global(state: CollectionState,
+                          player: int,
+                          multiworld: MultiWorld) -> int:
 
     accessible_orbs = 0
     for region in multiworld.get_regions(player):
         if state.can_reach(region, "Region", player):
             accessible_orbs += typing.cast(JakAndDaxterRegion, region).orb_count
+
+    return accessible_orbs
+
+
+def can_reach_orbs_level(state: CollectionState,
+                         player: int,
+                         multiworld: MultiWorld,
+                         level_name: str) -> int:
+
+    accessible_orbs = 0
+    regions = [typing.cast(JakAndDaxterRegion, reg) for reg in multiworld.get_regions(player)]
+    for region in regions:
+        if region.level_name == level_name and state.can_reach(region, "Region", player):
+            accessible_orbs += region.orb_count
 
     return accessible_orbs
 
@@ -29,8 +57,11 @@ def can_trade(state: CollectionState,
               required_orbs: int,
               required_previous_trade: int = None) -> bool:
 
-    if options.enable_orbsanity.value > 0:
-        bundle_size = options.enable_orbsanity.value
+    if options.enable_orbsanity.value == 1:
+        bundle_size = options.level_orbsanity_bundle_size.value
+        return can_trade_orbsanity(state, player, bundle_size, required_orbs, required_previous_trade)
+    elif options.enable_orbsanity.value == 2:
+        bundle_size = options.global_orbsanity_bundle_size.value
         return can_trade_orbsanity(state, player, bundle_size, required_orbs, required_previous_trade)
     else:
         return can_trade_regular(state, player, multiworld, required_orbs, required_previous_trade)
@@ -42,7 +73,8 @@ def can_trade_regular(state: CollectionState,
                       required_orbs: int,
                       required_previous_trade: int = None) -> bool:
 
-    accessible_orbs = can_reach_orbs(state, player, multiworld)
+    # We know that Orbsanity is off, so count orbs globally.
+    accessible_orbs = can_reach_orbs_global(state, player, multiworld)
     if required_previous_trade:
         name_of_previous_trade = location_table[Cells.to_ap_id(required_previous_trade)]
         return (accessible_orbs >= required_orbs

--- a/worlds/jakanddaxter/Rules.py
+++ b/worlds/jakanddaxter/Rules.py
@@ -1,9 +1,9 @@
 import typing
 from BaseClasses import MultiWorld, CollectionState
 from .JakAndDaxterOptions import JakAndDaxterOptions
-from .locs import CellLocations as Cells
+from .locs import CellLocations as Cells, OrbLocations as Orbs
 from .Locations import location_table
-from .Regions import JakAndDaxterRegion
+from .regs.RegionBase import JakAndDaxterRegion
 
 
 # TODO - Until we come up with a better progressive system for the traders (that avoids hard-locking if you pay the
@@ -25,6 +25,19 @@ def can_trade(state: CollectionState,
                 and state.can_reach(name_of_previous_trade, "Location", player=player))
     else:
         return accessible_orbs >= required_orbs
+
+
+def can_reach_orb(state: CollectionState,
+                  player: int,
+                  multiworld: MultiWorld,
+                  orb_number: int) -> bool:
+
+    accessible_orbs = 0
+    for region in multiworld.get_regions(player):
+        if state.can_reach(region, "Region", player):
+            accessible_orbs += typing.cast(JakAndDaxterRegion, region).orb_count
+
+    return accessible_orbs >= orb_number
 
 
 def can_free_scout_flies(state: CollectionState, player: int) -> bool:

--- a/worlds/jakanddaxter/Rules.py
+++ b/worlds/jakanddaxter/Rules.py
@@ -1,9 +1,23 @@
+import math
 import typing
 from BaseClasses import MultiWorld, CollectionState
 from .JakAndDaxterOptions import JakAndDaxterOptions
+from .Items import orb_item_table
 from .locs import CellLocations as Cells, OrbLocations as Orbs
 from .Locations import location_table
 from .regs.RegionBase import JakAndDaxterRegion
+
+
+def can_reach_orbs(state: CollectionState,
+                   player: int,
+                   multiworld: MultiWorld) -> int:
+
+    accessible_orbs = 0
+    for region in multiworld.get_regions(player):
+        if state.can_reach(region, "Region", player):
+            accessible_orbs += typing.cast(JakAndDaxterRegion, region).orb_count
+
+    return accessible_orbs
 
 
 # TODO - Until we come up with a better progressive system for the traders (that avoids hard-locking if you pay the
@@ -11,14 +25,24 @@ from .regs.RegionBase import JakAndDaxterRegion
 def can_trade(state: CollectionState,
               player: int,
               multiworld: MultiWorld,
+              options: JakAndDaxterOptions,
               required_orbs: int,
               required_previous_trade: int = None) -> bool:
 
-    accessible_orbs = 0
-    for region in multiworld.get_regions(player):
-        if state.can_reach(region, "Region", player):
-            accessible_orbs += typing.cast(JakAndDaxterRegion, region).orb_count
+    if options.enable_orbsanity.value > 0:
+        bundle_size = options.enable_orbsanity.value
+        return can_trade_orbsanity(state, player, bundle_size, required_orbs, required_previous_trade)
+    else:
+        return can_trade_regular(state, player, multiworld, required_orbs, required_previous_trade)
 
+
+def can_trade_regular(state: CollectionState,
+                      player: int,
+                      multiworld: MultiWorld,
+                      required_orbs: int,
+                      required_previous_trade: int = None) -> bool:
+
+    accessible_orbs = can_reach_orbs(state, player, multiworld)
     if required_previous_trade:
         name_of_previous_trade = location_table[Cells.to_ap_id(required_previous_trade)]
         return (accessible_orbs >= required_orbs
@@ -27,17 +51,20 @@ def can_trade(state: CollectionState,
         return accessible_orbs >= required_orbs
 
 
-def can_reach_orbs(state: CollectionState,
-                   player: int,
-                   multiworld: MultiWorld,
-                   orb_count: int) -> bool:
+def can_trade_orbsanity(state: CollectionState,
+                        player: int,
+                        orb_bundle_size: int,
+                        required_orbs: int,
+                        required_previous_trade: int = None) -> bool:
 
-    accessible_orbs = 0
-    for region in multiworld.get_regions(player):
-        if state.can_reach(region, "Region", player):
-            accessible_orbs += typing.cast(JakAndDaxterRegion, region).orb_count
-
-    return accessible_orbs >= orb_count
+    required_count = math.ceil(required_orbs / orb_bundle_size)
+    orb_bundle_name = orb_item_table[orb_bundle_size]
+    if required_previous_trade:
+        name_of_previous_trade = location_table[Cells.to_ap_id(required_previous_trade)]
+        return (state.has(orb_bundle_name, player, required_count)
+                and state.can_reach(name_of_previous_trade, "Location", player=player))
+    else:
+        return state.has(orb_bundle_name, player, required_count)
 
 
 def can_free_scout_flies(state: CollectionState, player: int) -> bool:

--- a/worlds/jakanddaxter/Rules.py
+++ b/worlds/jakanddaxter/Rules.py
@@ -27,17 +27,17 @@ def can_trade(state: CollectionState,
         return accessible_orbs >= required_orbs
 
 
-def can_reach_orb(state: CollectionState,
-                  player: int,
-                  multiworld: MultiWorld,
-                  orb_number: int) -> bool:
+def can_reach_orbs(state: CollectionState,
+                   player: int,
+                   multiworld: MultiWorld,
+                   orb_count: int) -> bool:
 
     accessible_orbs = 0
     for region in multiworld.get_regions(player):
         if state.can_reach(region, "Region", player):
             accessible_orbs += typing.cast(JakAndDaxterRegion, region).orb_count
 
-    return accessible_orbs >= orb_number
+    return accessible_orbs >= orb_count
 
 
 def can_free_scout_flies(state: CollectionState, player: int) -> bool:

--- a/worlds/jakanddaxter/__init__.py
+++ b/worlds/jakanddaxter/__init__.py
@@ -1,4 +1,4 @@
-import typing
+from typing import Dict, Any, ClassVar
 import settings
 
 from Utils import local_path, visualize_regions
@@ -66,7 +66,7 @@ class JakAndDaxterWorld(World):
     required_client_version = (0, 4, 6)
 
     # Options
-    settings: typing.ClassVar[JakAndDaxterSettings]
+    settings: ClassVar[JakAndDaxterSettings]
     options_dataclass = JakAndDaxterOptions
     options: JakAndDaxterOptions
 
@@ -176,3 +176,9 @@ class JakAndDaxterWorld(World):
 
     def get_filler_item_name(self) -> str:
         return "Green Eco Pill"
+
+    def fill_slot_data(self) -> Dict[str, Any]:
+        return self.options.as_dict("enable_move_randomizer",
+                                    "enable_orbsanity",
+                                    "global_orbsanity_bundle_size",
+                                    "level_orbsanity_bundle_size")

--- a/worlds/jakanddaxter/__init__.py
+++ b/worlds/jakanddaxter/__init__.py
@@ -120,10 +120,10 @@ class JakAndDaxterWorld(World):
             classification = ItemClassification.progression
             count = 1
 
-        # TODO - Make 2000 Precursor Orbs, ONLY IF Orbsanity is enabled.
+        # Make 2000 Precursor Orbs.
         elif item in range(jak1_id + Orbs.orb_offset, jak1_max):
             classification = ItemClassification.progression_skip_balancing
-            count = 0
+            count = 2000
 
         # Under normal circumstances, we will create 0 filler items.
         # We will manually create filler items as needed.
@@ -146,6 +146,13 @@ class JakAndDaxterWorld(World):
             if not self.options.enable_move_randomizer and item_table[item_id] in self.item_name_groups["Moves"]:
                 self.multiworld.push_precollected(self.create_item(item_table[item_id]))
                 self.multiworld.itempool += [self.create_item(self.get_filler_item_name())]
+
+            # Handle Orbsanity option.
+            # If it is OFF, don't add any orbs to the item pool.
+            elif not self.options.enable_orbsanity and item_table[item_id] in self.item_name_groups["Precursor Orbs"]:
+                pass
+
+            # Every other scenario.
             else:
                 count, classification = self.item_type_helper(item_id)
                 self.multiworld.itempool += [JakAndDaxterItem(item_table[item_id], classification, item_id, self.player)

--- a/worlds/jakanddaxter/client/MemoryReader.py
+++ b/worlds/jakanddaxter/client/MemoryReader.py
@@ -289,15 +289,18 @@ class JakAndDaxterMemoryReader:
             collected_bundle_count = self.read_goal_address(collected_bundle_count_offset, sizeof_uint32)
 
             if orbsanity_option > 0 and collected_bundle_count > 0:
-                bundle_ap_id = Orbs.to_ap_id(Orbs.find_address(collected_bundle_level,
-                                                               collected_bundle_count,
-                                                               orbsanity_bundle))
+                # Count up from the first bundle, by bundle size, until you reach the latest collected bundle.
+                # e.g. {25, 50, 75, 100, 125...}
+                for k in range(orbsanity_bundle,
+                               orbsanity_bundle + collected_bundle_count,  # Range max is non-inclusive.
+                               orbsanity_bundle):
 
-                if bundle_ap_id not in self.location_outbox:
-                    self.location_outbox.append(bundle_ap_id)
-                    logger.debug("Checked orb bundle: " + str(bundle_ap_id))
+                    bundle_ap_id = Orbs.to_ap_id(Orbs.find_address(collected_bundle_level, k, orbsanity_bundle))
+                    if bundle_ap_id not in self.location_outbox:
+                        self.location_outbox.append(bundle_ap_id)
+                        logger.debug("Checked orb bundle: " + str(bundle_ap_id))
 
-                self.reset_orbsanity = True
+                # self.reset_orbsanity = True
 
         except (ProcessError, MemoryReadError, WinAPIError):
             logger.error("The gk process has died. Restart the game and run \"/memr connect\" again.")

--- a/worlds/jakanddaxter/client/MemoryReader.py
+++ b/worlds/jakanddaxter/client/MemoryReader.py
@@ -1,5 +1,5 @@
 import random
-import typing
+from typing import ByteString, List, Callable
 import json
 import pymem
 from pymem import pattern
@@ -7,7 +7,8 @@ from pymem.exception import ProcessNotFound, ProcessError, MemoryReadError, WinA
 from dataclasses import dataclass
 
 from CommonClient import logger
-from ..locs import (CellLocations as Cells,
+from ..locs import (OrbLocations as Orbs,
+                    CellLocations as Cells,
                     ScoutLocations as Flies,
                     SpecialLocations as Specials,
                     OrbCacheLocations as Caches)
@@ -65,6 +66,12 @@ orb_caches_checked_offset = offsets.define(sizeof_uint32, 16)
 moves_received_offset = offsets.define(sizeof_uint8, 16)
 moverando_enabled_offset = offsets.define(sizeof_uint8)
 
+# Orbsanity information.
+orbsanity_option_offset = offsets.define(sizeof_uint8)
+orbsanity_bundle_offset = offsets.define(sizeof_uint32)
+collected_bundle_level_offset = offsets.define(sizeof_uint8)
+collected_bundle_count_offset = offsets.define(sizeof_uint32)
+
 # The End.
 end_marker_offset = offsets.define(sizeof_uint8, 4)
 
@@ -111,7 +118,7 @@ def autopsy(died: int) -> str:
 
 
 class JakAndDaxterMemoryReader:
-    marker: typing.ByteString
+    marker: ByteString
     goal_address = None
     connected: bool = False
     initiated_connect: bool = False
@@ -128,15 +135,20 @@ class JakAndDaxterMemoryReader:
     send_deathlink: bool = False
     cause_of_death: str = ""
 
-    def __init__(self, marker: typing.ByteString = b'UnLiStEdStRaTs_JaK1\x00'):
+    # Orbsanity handling
+    orbsanity_enabled: bool = False
+    reset_orbsanity: bool = False
+
+    def __init__(self, marker: ByteString = b'UnLiStEdStRaTs_JaK1\x00'):
         self.marker = marker
         self.connect()
 
     async def main_tick(self,
-                        location_callback: typing.Callable,
-                        finish_callback: typing.Callable,
-                        deathlink_callback: typing.Callable,
-                        deathlink_toggle: typing.Callable):
+                        location_callback: Callable,
+                        finish_callback: Callable,
+                        deathlink_callback: Callable,
+                        deathlink_toggle: Callable,
+                        orbsanity_callback: Callable):
         if self.initiated_connect:
             await self.connect()
             self.initiated_connect = False
@@ -170,6 +182,9 @@ class JakAndDaxterMemoryReader:
 
         if self.send_deathlink:
             deathlink_callback()
+
+        if self.reset_orbsanity:
+            orbsanity_callback()
 
     async def connect(self):
         try:
@@ -207,7 +222,7 @@ class JakAndDaxterMemoryReader:
         logger.info("   Last location checked: " + (str(self.location_outbox[self.outbox_index])
                                                     if self.outbox_index else "None"))
 
-    def read_memory(self) -> typing.List[int]:
+    def read_memory(self) -> List[int]:
         try:
             next_cell_index = self.read_goal_address(0, sizeof_uint64)
             next_buzzer_index = self.read_goal_address(next_buzzer_index_offset, sizeof_uint64)
@@ -262,8 +277,27 @@ class JakAndDaxterMemoryReader:
                     logger.debug("Checked orb cache: " + str(next_cache))
 
             # Listen for any changes to this setting.
-            moverando_flag = self.read_goal_address(moverando_enabled_offset, sizeof_uint8)
-            self.moverando_enabled = bool(moverando_flag)
+            # moverando_flag = self.read_goal_address(moverando_enabled_offset, sizeof_uint8)
+            # self.moverando_enabled = bool(moverando_flag)
+
+            orbsanity_option = self.read_goal_address(orbsanity_option_offset, sizeof_uint8)
+            self.orbsanity_enabled = orbsanity_option > 0
+
+            # Treat these values like the Deathlink flag. They need to be reset once they are checked.
+            collected_bundle_level = self.read_goal_address(collected_bundle_level_offset, sizeof_uint8)
+            collected_bundle_count = self.read_goal_address(collected_bundle_count_offset, sizeof_uint32)
+
+            if orbsanity_option > 0 and collected_bundle_count > 0:
+                if orbsanity_option > 1:
+                    bundle_ap_id = Orbs.find_address(0, collected_bundle_count)  # Global => level_index = 0.
+                else:
+                    bundle_ap_id = Orbs.find_address(collected_bundle_level, collected_bundle_count)
+
+                if bundle_ap_id not in self.location_outbox:
+                    self.location_outbox.append(bundle_ap_id)
+                    logger.debug("Checked orb bundle: " + str(bundle_ap_id))
+
+                self.reset_orbsanity = True
 
         except (ProcessError, MemoryReadError, WinAPIError):
             logger.error("The gk process has died. Restart the game and run \"/memr connect\" again.")

--- a/worlds/jakanddaxter/client/MemoryReader.py
+++ b/worlds/jakanddaxter/client/MemoryReader.py
@@ -281,6 +281,7 @@ class JakAndDaxterMemoryReader:
             # self.moverando_enabled = bool(moverando_flag)
 
             orbsanity_option = self.read_goal_address(orbsanity_option_offset, sizeof_uint8)
+            orbsanity_bundle = self.read_goal_address(orbsanity_bundle_offset, sizeof_uint32)
             self.orbsanity_enabled = orbsanity_option > 0
 
             # Treat these values like the Deathlink flag. They need to be reset once they are checked.
@@ -288,10 +289,9 @@ class JakAndDaxterMemoryReader:
             collected_bundle_count = self.read_goal_address(collected_bundle_count_offset, sizeof_uint32)
 
             if orbsanity_option > 0 and collected_bundle_count > 0:
-                if orbsanity_option > 1:
-                    bundle_ap_id = Orbs.find_address(0, collected_bundle_count)  # Global => level_index = 0.
-                else:
-                    bundle_ap_id = Orbs.find_address(collected_bundle_level, collected_bundle_count)
+                bundle_ap_id = Orbs.to_ap_id(Orbs.find_address(collected_bundle_level,
+                                                               collected_bundle_count,
+                                                               orbsanity_bundle))
 
                 if bundle_ap_id not in self.location_outbox:
                     self.location_outbox.append(bundle_ap_id)

--- a/worlds/jakanddaxter/client/ReplClient.py
+++ b/worlds/jakanddaxter/client/ReplClient.py
@@ -257,15 +257,15 @@ class JakAndDaxterReplClient:
         return ok
 
     def receive_precursor_orb(self, ap_id: int) -> bool:
-        orb_id = Orbs.to_game_id(ap_id)
+        orb_amount = Orbs.to_game_id(ap_id)
         ok = self.send_form("(send-event "
                             "*target* \'get-archipelago "
                             "(pickup-type money) "
-                            "(the float " + str(orb_id) + "))")
+                            "(the float " + str(orb_amount) + "))")
         if ok:
-            logger.debug(f"Received a Precursor Orb!")
+            logger.debug(f"Received {orb_amount} Precursor Orbs!")
         else:
-            logger.error(f"Unable to receive a Precursor Orb!")
+            logger.error(f"Unable to receive {orb_amount} Precursor Orbs!")
         return ok
 
     # Green eco pills are our filler item. Use the get-pickup event instead to handle being full health.
@@ -306,6 +306,34 @@ class JakAndDaxterReplClient:
             logger.debug(f"Reset deathlink flag!")
         else:
             logger.error(f"Unable to reset deathlink flag!")
+        return ok
+
+    def setup_orbsanity(self, option: int, bundle: int) -> bool:
+        ok = self.send_form(f"(set! (-> *ap-info-jak1* orbsanity-option) {option})")
+        if ok:
+            logger.debug(f"Set orbsanity flag to {option}!")
+        else:
+            logger.error(f"Unable to set orbsanity flag!")
+
+        ok = self.send_form(f"(set! (-> *ap-info-jak1* orbsanity-bundle) {bundle})")
+        if ok:
+            logger.debug(f"Set orbsanity bundle size to {bundle}!")
+        else:
+            logger.error(f"Unable to set orbsanity bundle size!")
+        return ok
+
+    def reset_orbsanity(self) -> bool:
+        ok = self.send_form(f"(set! (-> *ap-info-jak1* collected-bundle-level) 0)")
+        if ok:
+            logger.debug(f"Reset level ID for collected orbsanity bundle!")
+        else:
+            logger.error(f"Unable to reset level ID for collected orbsanity bundle!")
+
+        ok = self.send_form(f"(set! (-> *ap-info-jak1* collected-bundle-count) 0)")
+        if ok:
+            logger.debug(f"Reset orb count for collected orbsanity bundle!")
+        else:
+            logger.error(f"Unable to reset orb count for collected orbsanity bundle!")
         return ok
 
     def save_data(self):

--- a/worlds/jakanddaxter/client/ReplClient.py
+++ b/worlds/jakanddaxter/client/ReplClient.py
@@ -309,17 +309,11 @@ class JakAndDaxterReplClient:
         return ok
 
     def setup_orbsanity(self, option: int, bundle: int) -> bool:
-        ok = self.send_form(f"(set! (-> *ap-info-jak1* orbsanity-option) {option})")
+        ok = self.send_form(f"(ap-setup-orbs! (the uint {option}) (the uint {bundle}))")
         if ok:
-            logger.debug(f"Set orbsanity flag to {option}!")
+            logger.debug(f"Set up orbsanity: Option {option}, Bundle {bundle}!")
         else:
-            logger.error(f"Unable to set orbsanity flag!")
-
-        ok = self.send_form(f"(set! (-> *ap-info-jak1* orbsanity-bundle) {bundle})")
-        if ok:
-            logger.debug(f"Set orbsanity bundle size to {bundle}!")
-        else:
-            logger.error(f"Unable to set orbsanity bundle size!")
+            logger.error(f"Unable to set up orbsanity: Option {option}, Bundle {bundle}!")
         return ok
 
     def reset_orbsanity(self) -> bool:

--- a/worlds/jakanddaxter/docs/setup_en.md
+++ b/worlds/jakanddaxter/docs/setup_en.md
@@ -29,11 +29,11 @@ At this time, this method of setup works on Windows only, but Linux support is a
   - `C:\Users\<YourName>\AppData\Roaming\OpenGOAL-Mods\archipelagoal\iso_data` should have *all* the same files as
   - `C:\Users\<YourName>\AppData\Roaming\OpenGOAL-Mods\_iso_data`, if it doesn't, copy those files over manually.
   - And then `Recompile` if you needed to copy the files over.
-- **DO NOT LAUNCH THE GAME FROM THE MOD LAUNCHER.** It will run in retail mode, which is incompatible with Archipelago. We need it to run in debug mode (see below).
+- **DO NOT PLAY AN ARCHIPELAGO GAME THROUGH THE MOD LAUNCHER.** It will run in retail mode, which is incompatible with Archipelago. We need it to run in debug mode (see below).
 
 ***Archipelago Launcher***
 
-- Copy the `jakanddaxter.apworld` file into your `Archipelago/lib/worlds` directory.
+- Copy the `jakanddaxter.apworld` file into your `Archipelago/custom_worlds` directory.
   - Reminder: the default installation location for Archipelago is `C:\ProgramData\Archipelago`.
 - Run the Archipelago Launcher.
 - From the left-most list, click `Generate Template Options`.
@@ -43,6 +43,20 @@ At this time, this method of setup works on Windows only, but Linux support is a
 - If you plan to host the game yourself, from the left-most list, click `Host`.
   - When asked to select your multiworld seed, navigate to `Archipelago/output` and select the zip file containing the seed you just generated.
   - You can sort by Date Modified to make it easy to find.
+
+## Updates and New Releases
+
+***OpenGOAL Mod Launcher***
+
+- Run the Mod Launcher and click `ArchipelaGOAL` in the mod list.
+- Click `Launch` to download and install any new updates that have been released.
+- You can verify your version once you reach the title screen menu by navigating to `Options > Game Options > Miscellaneous > Speedrunner Mode`.
+- Turn on `Speedrunner Mode` and exit the menu. You should see the installed version number in the bottom left corner. Then turn `Speedrunner Mode` back off.
+- Once you've verified your version, you can close the game. Remember, this is just for downloading updates. **DO NOT PLAY AN ARCHIPELAGO GAME THROUGH THE MOD LAUNCHER.**
+ 
+***Archipelago Launcher***
+
+- Copy the latest `jakanddaxter.apworld` file into your `Archipelago/custom_worlds` directory.
 
 ## Starting a Game
 

--- a/worlds/jakanddaxter/locs/OrbLocations.py
+++ b/worlds/jakanddaxter/locs/OrbLocations.py
@@ -33,14 +33,13 @@ def to_game_id(ap_id: int) -> int:
     return ap_id - jak1_id - orb_offset  # Reverse process, subtract the offsets.
 
 
-@dataclass
-class OrbBundleFactory:
-    current_bundle: int = 0
-
-    def make_new_address(self) -> int:
-        result = to_ap_id(self.current_bundle)
-        self.current_bundle += 1
-        return result
+# Use this when the Memory Reader learns that you checked a specific bundle.
+def find_address(level_index: int, orb_count: int):
+    result = to_ap_id((level_index * 200) + orb_count)  # No level has > 200 orbs.
+    return result
 
 
-orb_factory = OrbBundleFactory()
+# Use this when assigning addresses during region generation.
+def create_address(level_index: int, bundle_index: int, bundle_size: int) -> int:
+    result = to_ap_id((level_index * 200) + (bundle_index * bundle_size))  # No level has > 200 orbs.
+    return result

--- a/worlds/jakanddaxter/locs/OrbLocations.py
+++ b/worlds/jakanddaxter/locs/OrbLocations.py
@@ -34,12 +34,95 @@ def to_game_id(ap_id: int) -> int:
 
 
 # Use this when the Memory Reader learns that you checked a specific bundle.
-def find_address(level_index: int, orb_count: int):
-    result = to_ap_id((level_index * 200) + orb_count)  # No level has > 200 orbs.
+# Offset each level by 200 orbs (max number in any level),      {200, 400, ...}
+# then divide orb count by bundle size,                         {201, 202, ...}
+# then subtract 1.                                              {200, 201, ...}
+def find_address(level_index: int, orb_count: int, bundle_size: int) -> int:
+    result = (level_index * 200) + (orb_count // bundle_size) - 1
     return result
 
 
 # Use this when assigning addresses during region generation.
-def create_address(level_index: int, bundle_index: int, bundle_size: int) -> int:
-    result = to_ap_id((level_index * 200) + (bundle_index * bundle_size))  # No level has > 200 orbs.
+def create_address(level_index: int, bundle_index: int) -> int:
+    result = (level_index * 200) + bundle_index
     return result
+
+
+# What follows is our method of generating all the name/ID pairs for location_name_to_id.
+# Remember that not every bundle will be used in the actual seed, we just need this as a static map of strings to ints.
+level_info = {
+    "": {
+        "level_index": 16,  # Global
+        "orbs": 2000
+    },
+    "Geyser Rock": {
+        "level_index": 0,
+        "orbs": 50
+    },
+    "Sandover Village": {
+        "level_index": 1,
+        "orbs": 50
+    },
+    "Sentinel Beach": {
+        "level_index": 2,
+        "orbs": 150
+    },
+    "Forbidden Jungle": {
+        "level_index": 3,
+        "orbs": 150
+    },
+    "Misty Island": {
+        "level_index": 4,
+        "orbs": 150
+    },
+    "Fire Canyon": {
+        "level_index": 5,
+        "orbs": 50
+    },
+    "Rock Village": {
+        "level_index": 6,
+        "orbs": 50
+    },
+    "Lost Precursor City": {
+        "level_index": 7,
+        "orbs": 200
+    },
+    "Boggy Swamp": {
+        "level_index": 8,
+        "orbs": 200
+    },
+    "Precursor Basin": {
+        "level_index": 9,
+        "orbs": 200
+    },
+    "Mountain Pass": {
+        "level_index": 10,
+        "orbs": 50
+    },
+    "Volcanic Crater": {
+        "level_index": 11,
+        "orbs": 50
+    },
+    "Snowy Mountain": {
+        "level_index": 12,
+        "orbs": 200
+    },
+    "Spider Cave": {
+        "level_index": 13,
+        "orbs": 200
+    },
+    "Lava Tube": {
+        "level_index": 14,
+        "orbs": 50
+    },
+    "Gol and Maia's Citadel": {
+        "level_index": 15,
+        "orbs": 200
+    }
+}
+
+loc_orbBundleTable = {
+    create_address(level_info[name]["level_index"], index): f"{name} Orb Bundle {index + 1}".strip()
+    for name in level_info
+    for index in range(level_info[name]["orbs"])
+}

--- a/worlds/jakanddaxter/locs/OrbLocations.py
+++ b/worlds/jakanddaxter/locs/OrbLocations.py
@@ -1,3 +1,5 @@
+from dataclasses import dataclass
+
 from ..GameID import jak1_id
 
 # Precursor Orbs are not necessarily given ID's by the game.
@@ -11,9 +13,9 @@ from ..GameID import jak1_id
 # from parent actors DON'T have an Actor ID themselves - the parent object keeps track of how many of its orbs
 # have been picked up.
 
-# Rather than dealing with this mess, we're instead creating a single table of 2000 Locations, each representing 1 orb.
-# When you pick up any orb in the game, you check the next progressive Location in the table. Each Location will have
-# an access rule that requires you to have the equivalent number of orbs in the all the regions you have access to.
+# In order to deal with this mess, we're creating a factory class that will generate Orb Locations for us.
+# This will be compatible with both Global Orbsanity and Per-Level Orbsanity, allowing us to create any
+# number of Locations depending on the bundle size chosen, while also guaranteeing that each has a unique address.
 
 # We can use 2^15 to offset them from Orb Caches, because Orb Cache ID's max out at (jak1_id + 17792).
 orb_offset = 32768
@@ -29,3 +31,16 @@ def to_ap_id(game_id: int) -> int:
 def to_game_id(ap_id: int) -> int:
     assert ap_id >= jak1_id, f"Attempted to convert {ap_id} to a Jak 1 ID, but it already is one."
     return ap_id - jak1_id - orb_offset  # Reverse process, subtract the offsets.
+
+
+@dataclass
+class OrbBundleFactory:
+    current_bundle: int = 0
+
+    def make_new_address(self) -> int:
+        result = to_ap_id(self.current_bundle)
+        self.current_bundle += 1
+        return result
+
+
+orb_factory = OrbBundleFactory()

--- a/worlds/jakanddaxter/locs/OrbLocations.py
+++ b/worlds/jakanddaxter/locs/OrbLocations.py
@@ -29,12 +29,3 @@ def to_ap_id(game_id: int) -> int:
 def to_game_id(ap_id: int) -> int:
     assert ap_id >= jak1_id, f"Attempted to convert {ap_id} to a Jak 1 ID, but it already is one."
     return ap_id - jak1_id - orb_offset  # Reverse process, subtract the offsets.
-
-
-# The ID's you see below have no correlation to the game.
-
-
-# The table.
-loc_orbTable = {
-    k: "Orb " + str(k + 1) for k in range(2000)
-}

--- a/worlds/jakanddaxter/locs/OrbLocations.py
+++ b/worlds/jakanddaxter/locs/OrbLocations.py
@@ -7,14 +7,13 @@ from ..GameID import jak1_id
 # so like Power Cells these are not ordered, nor contiguous, nor exclusively orbs.
 
 # In fact, other ID's in this range belong to actors that spawn orbs when they are activated or when they die,
-# like steel crates, orb caches, Spider Cave gnawers, or jumping on the Plant Boss's head.
+# like steel crates, orb caches, Spider Cave gnawers, or jumping on the Plant Boss's head. These orbs that spawn
+# from parent actors DON'T have an Actor ID themselves - the parent object keeps track of how many of its orbs
+# have been picked up.
 
-# These orbs that spawn from parent actors DON'T have an Actor ID themselves - the parent object keeps
-# track of how many of its orbs have been picked up. If you pick up only some of its orbs, it
-# will respawn when you leave the area, and only drop the remaining number of orbs when activated/killed.
-# Once all the orbs are picked up, the actor will permanently "retire" and never spawn again.
-# The maximum number of orbs that any actor can spawn is 30 (the orb caches in citadel). Covering
-# these ID-less orbs may need to be a future enhancement. TODO ^^
+# Rather than dealing with this mess, we're instead creating a single table of 2000 Locations, each representing 1 orb.
+# When you pick up any orb in the game, you check the next progressive Location in the table. Each Location will have
+# an access rule that requires you to have the equivalent number of orbs in the all the regions you have access to.
 
 # We can use 2^15 to offset them from Orb Caches, because Orb Cache ID's max out at (jak1_id + 17792).
 orb_offset = 32768
@@ -32,68 +31,10 @@ def to_game_id(ap_id: int) -> int:
     return ap_id - jak1_id - orb_offset  # Reverse process, subtract the offsets.
 
 
-# The ID's you see below correspond directly to that orb's Actor ID in the game.
+# The ID's you see below have no correlation to the game.
 
-# Geyser Rock
-locGR_orbTable = {
-}
 
-# Sandover Village
-locSV_orbTable = {
-}
-
-# Forbidden Jungle
-locFJ_orbTable = {
-}
-
-# Sentinel Beach
-locSB_orbTable = {
-}
-
-# Misty Island
-locMI_orbTable = {
-}
-
-# Fire Canyon
-locFC_orbTable = {
-}
-
-# Rock Village
-locRV_orbTable = {
-}
-
-# Precursor Basin
-locPB_orbTable = {
-}
-
-# Lost Precursor City
-locLPC_orbTable = {
-}
-
-# Boggy Swamp
-locBS_orbTable = {
-}
-
-# Mountain Pass
-locMP_orbTable = {
-}
-
-# Volcanic Crater
-locVC_orbTable = {
-}
-
-# Spider Cave
-locSC_orbTable = {
-}
-
-# Snowy Mountain
-locSM_orbTable = {
-}
-
-# Lava Tube
-locLT_orbTable = {
-}
-
-# Gol and Maias Citadel
-locGMC_orbTable = {
+# The table.
+loc_orbTable = {
+    k: "Orb " + str(k + 1) for k in range(2000)
 }

--- a/worlds/jakanddaxter/regs/BoggySwampRegions.py
+++ b/worlds/jakanddaxter/regs/BoggySwampRegions.py
@@ -21,6 +21,7 @@ def build_regions(level_name: str, multiworld: MultiWorld, options: JakAndDaxter
                 or (state.has("Punch", p) and state.has("Punch Uppercut", p)))
 
     # Orb crates and fly box in this area can be gotten with yellow eco and goggles.
+    # Start with the first yellow eco cluster near first_bats and work your way backward toward the entrance.
     main_area = JakAndDaxterRegion("Main Area", player, multiworld, level_name, 23)
     main_area.add_fly_locations([43])
 

--- a/worlds/jakanddaxter/regs/BoggySwampRegions.py
+++ b/worlds/jakanddaxter/regs/BoggySwampRegions.py
@@ -159,8 +159,11 @@ def build_regions(level_name: str, multiworld: MultiWorld, options: JakAndDaxter
 
         bundle_size = options.level_orbsanity_bundle_size.value
         bundle_count = int(200 / bundle_size)
-        for bundle_id in range(bundle_count):
-            orbs.add_orb_locations(bundle_id, access_rule=lambda state, bundle=bundle_id:
+        for bundle_index in range(bundle_count):
+            orbs.add_orb_locations(8,
+                                   bundle_index,
+                                   bundle_size,
+                                   access_rule=lambda state, bundle=bundle_index:
                                    can_reach_orbs(state, player, multiworld, options, level_name)
                                    >= (bundle_size * (bundle + 1)))
         multiworld.regions.append(orbs)

--- a/worlds/jakanddaxter/regs/BoggySwampRegions.py
+++ b/worlds/jakanddaxter/regs/BoggySwampRegions.py
@@ -2,7 +2,7 @@ from typing import List
 from BaseClasses import CollectionState, MultiWorld
 from .RegionBase import JakAndDaxterRegion
 from .. import JakAndDaxterOptions
-from ..Rules import can_fight
+from ..Rules import can_fight, can_reach_orbs
 
 
 def build_regions(level_name: str, multiworld: MultiWorld, options: JakAndDaxterOptions, player: int) -> List[JakAndDaxterRegion]:
@@ -151,5 +151,19 @@ def build_regions(level_name: str, multiworld: MultiWorld, options: JakAndDaxter
     multiworld.regions.append(box_field)
     multiworld.regions.append(last_tar_pit)
     multiworld.regions.append(fourth_tether)
+
+    # If Per-Level Orbsanity is enabled, build the special Orbsanity Region. This is a virtual region always
+    # accessible to Main Area. The Locations within are automatically checked when you collect enough orbs.
+    if options.enable_orbsanity.value == 1:
+        orbs = JakAndDaxterRegion("Orbsanity", player, multiworld, level_name)
+
+        bundle_size = options.level_orbsanity_bundle_size.value
+        bundle_count = int(200 / bundle_size)
+        for bundle_id in range(bundle_count):
+            orbs.add_orb_locations(bundle_id, access_rule=lambda state, bundle=bundle_id:
+                                   can_reach_orbs(state, player, multiworld, options, level_name)
+                                   >= (bundle_size * (bundle + 1)))
+        multiworld.regions.append(orbs)
+        main_area.connect(orbs)
 
     return [main_area]

--- a/worlds/jakanddaxter/regs/BoggySwampRegions.py
+++ b/worlds/jakanddaxter/regs/BoggySwampRegions.py
@@ -1,10 +1,11 @@
 from typing import List
 from BaseClasses import CollectionState, MultiWorld
 from .RegionBase import JakAndDaxterRegion
+from .. import JakAndDaxterOptions
 from ..Rules import can_fight
 
 
-def build_regions(level_name: str, player: int, multiworld: MultiWorld) -> List[JakAndDaxterRegion]:
+def build_regions(level_name: str, multiworld: MultiWorld, options: JakAndDaxterOptions, player: int) -> List[JakAndDaxterRegion]:
 
     # This level is full of short-medium gaps that cannot be crossed by single jump alone.
     # These helper functions list out the moves that can cross all these gaps (painting with a broad brush but...)

--- a/worlds/jakanddaxter/regs/FireCanyonRegions.py
+++ b/worlds/jakanddaxter/regs/FireCanyonRegions.py
@@ -1,10 +1,11 @@
 from typing import List
 from BaseClasses import CollectionState, MultiWorld
 from .RegionBase import JakAndDaxterRegion
+from .. import JakAndDaxterOptions
 from ..locs import CellLocations as Cells, ScoutLocations as Scouts
 
 
-def build_regions(level_name: str, player: int, multiworld: MultiWorld) -> List[JakAndDaxterRegion]:
+def build_regions(level_name: str, multiworld: MultiWorld, options: JakAndDaxterOptions, player: int) -> List[JakAndDaxterRegion]:
 
     main_area = JakAndDaxterRegion("Main Area", player, multiworld, level_name, 50)
 

--- a/worlds/jakanddaxter/regs/FireCanyonRegions.py
+++ b/worlds/jakanddaxter/regs/FireCanyonRegions.py
@@ -2,6 +2,7 @@ from typing import List
 from BaseClasses import CollectionState, MultiWorld
 from .RegionBase import JakAndDaxterRegion
 from .. import JakAndDaxterOptions
+from ..Rules import can_reach_orbs
 from ..locs import CellLocations as Cells, ScoutLocations as Scouts
 
 
@@ -14,5 +15,19 @@ def build_regions(level_name: str, multiworld: MultiWorld, options: JakAndDaxter
     main_area.add_fly_locations(Scouts.locFC_scoutTable.keys())
 
     multiworld.regions.append(main_area)
+
+    # If Per-Level Orbsanity is enabled, build the special Orbsanity Region. This is a virtual region always
+    # accessible to Main Area. The Locations within are automatically checked when you collect enough orbs.
+    if options.enable_orbsanity.value == 1:
+        orbs = JakAndDaxterRegion("Orbsanity", player, multiworld, level_name)
+
+        bundle_size = options.level_orbsanity_bundle_size.value
+        bundle_count = int(50 / bundle_size)
+        for bundle_id in range(bundle_count):
+            orbs.add_orb_locations(bundle_id, access_rule=lambda state, bundle=bundle_id:
+                                   can_reach_orbs(state, player, multiworld, options, level_name)
+                                   >= (bundle_size * (bundle + 1)))
+        multiworld.regions.append(orbs)
+        main_area.connect(orbs)
 
     return [main_area]

--- a/worlds/jakanddaxter/regs/FireCanyonRegions.py
+++ b/worlds/jakanddaxter/regs/FireCanyonRegions.py
@@ -23,8 +23,11 @@ def build_regions(level_name: str, multiworld: MultiWorld, options: JakAndDaxter
 
         bundle_size = options.level_orbsanity_bundle_size.value
         bundle_count = int(50 / bundle_size)
-        for bundle_id in range(bundle_count):
-            orbs.add_orb_locations(bundle_id, access_rule=lambda state, bundle=bundle_id:
+        for bundle_index in range(bundle_count):
+            orbs.add_orb_locations(5,
+                                   bundle_index,
+                                   bundle_size,
+                                   access_rule=lambda state, bundle=bundle_index:
                                    can_reach_orbs(state, player, multiworld, options, level_name)
                                    >= (bundle_size * (bundle + 1)))
         multiworld.regions.append(orbs)

--- a/worlds/jakanddaxter/regs/ForbiddenJungleRegions.py
+++ b/worlds/jakanddaxter/regs/ForbiddenJungleRegions.py
@@ -88,8 +88,11 @@ def build_regions(level_name: str, multiworld: MultiWorld, options: JakAndDaxter
 
         bundle_size = options.level_orbsanity_bundle_size.value
         bundle_count = int(150 / bundle_size)
-        for bundle_id in range(bundle_count):
-            orbs.add_orb_locations(bundle_id, access_rule=lambda state, bundle=bundle_id:
+        for bundle_index in range(bundle_count):
+            orbs.add_orb_locations(3,
+                                   bundle_index,
+                                   bundle_size,
+                                   access_rule=lambda state, bundle=bundle_index:
                                    can_reach_orbs(state, player, multiworld, options, level_name)
                                    >= (bundle_size * (bundle + 1)))
         multiworld.regions.append(orbs)

--- a/worlds/jakanddaxter/regs/ForbiddenJungleRegions.py
+++ b/worlds/jakanddaxter/regs/ForbiddenJungleRegions.py
@@ -1,10 +1,11 @@
 from typing import List
 from BaseClasses import CollectionState, MultiWorld
 from .RegionBase import JakAndDaxterRegion
+from .. import JakAndDaxterOptions
 from ..Rules import can_free_scout_flies, can_fight
 
 
-def build_regions(level_name: str, player: int, multiworld: MultiWorld) -> List[JakAndDaxterRegion]:
+def build_regions(level_name: str, multiworld: MultiWorld, options: JakAndDaxterOptions, player: int) -> List[JakAndDaxterRegion]:
 
     main_area = JakAndDaxterRegion("Main Area", player, multiworld, level_name, 25)
 

--- a/worlds/jakanddaxter/regs/ForbiddenJungleRegions.py
+++ b/worlds/jakanddaxter/regs/ForbiddenJungleRegions.py
@@ -2,7 +2,7 @@ from typing import List
 from BaseClasses import CollectionState, MultiWorld
 from .RegionBase import JakAndDaxterRegion
 from .. import JakAndDaxterOptions
-from ..Rules import can_free_scout_flies, can_fight
+from ..Rules import can_free_scout_flies, can_fight, can_reach_orbs
 
 
 def build_regions(level_name: str, multiworld: MultiWorld, options: JakAndDaxterOptions, player: int) -> List[JakAndDaxterRegion]:
@@ -80,5 +80,19 @@ def build_regions(level_name: str, multiworld: MultiWorld, options: JakAndDaxter
     multiworld.regions.append(temple_exterior)
     multiworld.regions.append(temple_int_pre_blue)
     multiworld.regions.append(temple_int_post_blue)
+
+    # If Per-Level Orbsanity is enabled, build the special Orbsanity Region. This is a virtual region always
+    # accessible to Main Area. The Locations within are automatically checked when you collect enough orbs.
+    if options.enable_orbsanity.value == 1:
+        orbs = JakAndDaxterRegion("Orbsanity", player, multiworld, level_name)
+
+        bundle_size = options.level_orbsanity_bundle_size.value
+        bundle_count = int(150 / bundle_size)
+        for bundle_id in range(bundle_count):
+            orbs.add_orb_locations(bundle_id, access_rule=lambda state, bundle=bundle_id:
+                                   can_reach_orbs(state, player, multiworld, options, level_name)
+                                   >= (bundle_size * (bundle + 1)))
+        multiworld.regions.append(orbs)
+        main_area.connect(orbs)
 
     return [main_area]

--- a/worlds/jakanddaxter/regs/GeyserRockRegions.py
+++ b/worlds/jakanddaxter/regs/GeyserRockRegions.py
@@ -32,8 +32,11 @@ def build_regions(level_name: str, multiworld: MultiWorld, options: JakAndDaxter
 
         bundle_size = options.level_orbsanity_bundle_size.value
         bundle_count = int(50 / bundle_size)
-        for bundle_id in range(bundle_count):
-            orbs.add_orb_locations(bundle_id, access_rule=lambda state, bundle=bundle_id:
+        for bundle_index in range(bundle_count):
+            orbs.add_orb_locations(0,
+                                   bundle_index,
+                                   bundle_size,
+                                   access_rule=lambda state, bundle=bundle_index:
                                    can_reach_orbs(state, player, multiworld, options, level_name)
                                    >= (bundle_size * (bundle + 1)))
         multiworld.regions.append(orbs)

--- a/worlds/jakanddaxter/regs/GeyserRockRegions.py
+++ b/worlds/jakanddaxter/regs/GeyserRockRegions.py
@@ -2,6 +2,7 @@ from typing import List
 from BaseClasses import CollectionState, MultiWorld
 from .RegionBase import JakAndDaxterRegion
 from .. import JakAndDaxterOptions
+from ..Rules import can_reach_orbs
 from ..locs import ScoutLocations as Scouts
 
 
@@ -23,5 +24,19 @@ def build_regions(level_name: str, multiworld: MultiWorld, options: JakAndDaxter
 
     multiworld.regions.append(main_area)
     multiworld.regions.append(cliff)
+
+    # If Per-Level Orbsanity is enabled, build the special Orbsanity Region. This is a virtual region always
+    # accessible to Main Area. The Locations within are automatically checked when you collect enough orbs.
+    if options.enable_orbsanity.value == 1:
+        orbs = JakAndDaxterRegion("Orbsanity", player, multiworld, level_name)
+
+        bundle_size = options.level_orbsanity_bundle_size.value
+        bundle_count = int(50 / bundle_size)
+        for bundle_id in range(bundle_count):
+            orbs.add_orb_locations(bundle_id, access_rule=lambda state, bundle=bundle_id:
+                                   can_reach_orbs(state, player, multiworld, options, level_name)
+                                   >= (bundle_size * (bundle + 1)))
+        multiworld.regions.append(orbs)
+        main_area.connect(orbs)
 
     return [main_area]

--- a/worlds/jakanddaxter/regs/GeyserRockRegions.py
+++ b/worlds/jakanddaxter/regs/GeyserRockRegions.py
@@ -1,10 +1,11 @@
 from typing import List
 from BaseClasses import CollectionState, MultiWorld
 from .RegionBase import JakAndDaxterRegion
+from .. import JakAndDaxterOptions
 from ..locs import ScoutLocations as Scouts
 
 
-def build_regions(level_name: str, player: int, multiworld: MultiWorld) -> List[JakAndDaxterRegion]:
+def build_regions(level_name: str, multiworld: MultiWorld, options: JakAndDaxterOptions, player: int) -> List[JakAndDaxterRegion]:
 
     main_area = JakAndDaxterRegion("Main Area", player, multiworld, level_name, 50)
     main_area.add_cell_locations([92, 93])

--- a/worlds/jakanddaxter/regs/GolAndMaiasCitadelRegions.py
+++ b/worlds/jakanddaxter/regs/GolAndMaiasCitadelRegions.py
@@ -120,8 +120,11 @@ def build_regions(level_name: str, multiworld: MultiWorld, options: JakAndDaxter
 
         bundle_size = options.level_orbsanity_bundle_size.value
         bundle_count = int(200 / bundle_size)
-        for bundle_id in range(bundle_count):
-            orbs.add_orb_locations(bundle_id, access_rule=lambda state, bundle=bundle_id:
+        for bundle_index in range(bundle_count):
+            orbs.add_orb_locations(15,
+                                   bundle_index,
+                                   bundle_size,
+                                   access_rule=lambda state, bundle=bundle_index:
                                    can_reach_orbs(state, player, multiworld, options, level_name)
                                    >= (bundle_size * (bundle + 1)))
         multiworld.regions.append(orbs)

--- a/worlds/jakanddaxter/regs/GolAndMaiasCitadelRegions.py
+++ b/worlds/jakanddaxter/regs/GolAndMaiasCitadelRegions.py
@@ -1,11 +1,12 @@
 from typing import List
 from BaseClasses import CollectionState, MultiWorld
 from .RegionBase import JakAndDaxterRegion
+from .. import JakAndDaxterOptions
 from ..Rules import can_free_scout_flies, can_fight
 
 
 # God help me... here we go.
-def build_regions(level_name: str, player: int, multiworld: MultiWorld) -> List[JakAndDaxterRegion]:
+def build_regions(level_name: str, multiworld: MultiWorld, options: JakAndDaxterOptions, player: int) -> List[JakAndDaxterRegion]:
 
     # This level is full of short-medium gaps that cannot be crossed by single jump alone.
     # These helper functions list out the moves that can cross all these gaps (painting with a broad brush but...)

--- a/worlds/jakanddaxter/regs/GolAndMaiasCitadelRegions.py
+++ b/worlds/jakanddaxter/regs/GolAndMaiasCitadelRegions.py
@@ -2,7 +2,7 @@ from typing import List
 from BaseClasses import CollectionState, MultiWorld
 from .RegionBase import JakAndDaxterRegion
 from .. import JakAndDaxterOptions
-from ..Rules import can_free_scout_flies, can_fight
+from ..Rules import can_free_scout_flies, can_fight, can_reach_orbs
 
 
 # God help me... here we go.
@@ -112,5 +112,19 @@ def build_regions(level_name: str, multiworld: MultiWorld, options: JakAndDaxter
     multiworld.regions.append(bunny_room)
     multiworld.regions.append(rotating_tower)
     multiworld.regions.append(final_boss)
+
+    # If Per-Level Orbsanity is enabled, build the special Orbsanity Region. This is a virtual region always
+    # accessible to Main Area. The Locations within are automatically checked when you collect enough orbs.
+    if options.enable_orbsanity.value == 1:
+        orbs = JakAndDaxterRegion("Orbsanity", player, multiworld, level_name)
+
+        bundle_size = options.level_orbsanity_bundle_size.value
+        bundle_count = int(200 / bundle_size)
+        for bundle_id in range(bundle_count):
+            orbs.add_orb_locations(bundle_id, access_rule=lambda state, bundle=bundle_id:
+                                   can_reach_orbs(state, player, multiworld, options, level_name)
+                                   >= (bundle_size * (bundle + 1)))
+        multiworld.regions.append(orbs)
+        main_area.connect(orbs)
 
     return [main_area, final_boss]

--- a/worlds/jakanddaxter/regs/LavaTubeRegions.py
+++ b/worlds/jakanddaxter/regs/LavaTubeRegions.py
@@ -2,6 +2,7 @@ from typing import List
 from BaseClasses import CollectionState, MultiWorld
 from .RegionBase import JakAndDaxterRegion
 from .. import JakAndDaxterOptions
+from ..Rules import can_reach_orbs
 from ..locs import CellLocations as Cells, ScoutLocations as Scouts
 
 
@@ -14,5 +15,19 @@ def build_regions(level_name: str, multiworld: MultiWorld, options: JakAndDaxter
     main_area.add_fly_locations(Scouts.locLT_scoutTable.keys())
 
     multiworld.regions.append(main_area)
+
+    # If Per-Level Orbsanity is enabled, build the special Orbsanity Region. This is a virtual region always
+    # accessible to Main Area. The Locations within are automatically checked when you collect enough orbs.
+    if options.enable_orbsanity.value == 1:
+        orbs = JakAndDaxterRegion("Orbsanity", player, multiworld, level_name)
+
+        bundle_size = options.level_orbsanity_bundle_size.value
+        bundle_count = int(50 / bundle_size)
+        for bundle_id in range(bundle_count):
+            orbs.add_orb_locations(bundle_id, access_rule=lambda state, bundle=bundle_id:
+                                   can_reach_orbs(state, player, multiworld, options, level_name)
+                                   >= (bundle_size * (bundle + 1)))
+        multiworld.regions.append(orbs)
+        main_area.connect(orbs)
 
     return [main_area]

--- a/worlds/jakanddaxter/regs/LavaTubeRegions.py
+++ b/worlds/jakanddaxter/regs/LavaTubeRegions.py
@@ -1,10 +1,11 @@
 from typing import List
 from BaseClasses import CollectionState, MultiWorld
 from .RegionBase import JakAndDaxterRegion
+from .. import JakAndDaxterOptions
 from ..locs import CellLocations as Cells, ScoutLocations as Scouts
 
 
-def build_regions(level_name: str, player: int, multiworld: MultiWorld) -> List[JakAndDaxterRegion]:
+def build_regions(level_name: str, multiworld: MultiWorld, options: JakAndDaxterOptions, player: int) -> List[JakAndDaxterRegion]:
 
     main_area = JakAndDaxterRegion("Main Area", player, multiworld, level_name, 50)
 

--- a/worlds/jakanddaxter/regs/LavaTubeRegions.py
+++ b/worlds/jakanddaxter/regs/LavaTubeRegions.py
@@ -23,8 +23,11 @@ def build_regions(level_name: str, multiworld: MultiWorld, options: JakAndDaxter
 
         bundle_size = options.level_orbsanity_bundle_size.value
         bundle_count = int(50 / bundle_size)
-        for bundle_id in range(bundle_count):
-            orbs.add_orb_locations(bundle_id, access_rule=lambda state, bundle=bundle_id:
+        for bundle_index in range(bundle_count):
+            orbs.add_orb_locations(14,
+                                   bundle_index,
+                                   bundle_size,
+                                   access_rule=lambda state, bundle=bundle_index:
                                    can_reach_orbs(state, player, multiworld, options, level_name)
                                    >= (bundle_size * (bundle + 1)))
         multiworld.regions.append(orbs)

--- a/worlds/jakanddaxter/regs/LostPrecursorCityRegions.py
+++ b/worlds/jakanddaxter/regs/LostPrecursorCityRegions.py
@@ -2,7 +2,7 @@ from typing import List
 from BaseClasses import CollectionState, MultiWorld
 from .RegionBase import JakAndDaxterRegion
 from .. import JakAndDaxterOptions
-from ..Rules import can_free_scout_flies, can_fight
+from ..Rules import can_free_scout_flies, can_fight, can_reach_orbs
 
 
 def build_regions(level_name: str, multiworld: MultiWorld, options: JakAndDaxterOptions, player: int) -> List[JakAndDaxterRegion]:
@@ -127,5 +127,19 @@ def build_regions(level_name: str, multiworld: MultiWorld, options: JakAndDaxter
     multiworld.regions.append(capsule_room)
     multiworld.regions.append(second_slide)
     multiworld.regions.append(helix_room)
+
+    # If Per-Level Orbsanity is enabled, build the special Orbsanity Region. This is a virtual region always
+    # accessible to Main Area. The Locations within are automatically checked when you collect enough orbs.
+    if options.enable_orbsanity.value == 1:
+        orbs = JakAndDaxterRegion("Orbsanity", player, multiworld, level_name)
+
+        bundle_size = options.level_orbsanity_bundle_size.value
+        bundle_count = int(200 / bundle_size)
+        for bundle_id in range(bundle_count):
+            orbs.add_orb_locations(bundle_id, access_rule=lambda state, bundle=bundle_id:
+                                   can_reach_orbs(state, player, multiworld, options, level_name)
+                                   >= (bundle_size * (bundle + 1)))
+        multiworld.regions.append(orbs)
+        main_area.connect(orbs)
 
     return [main_area]

--- a/worlds/jakanddaxter/regs/LostPrecursorCityRegions.py
+++ b/worlds/jakanddaxter/regs/LostPrecursorCityRegions.py
@@ -1,10 +1,11 @@
 from typing import List
 from BaseClasses import CollectionState, MultiWorld
 from .RegionBase import JakAndDaxterRegion
+from .. import JakAndDaxterOptions
 from ..Rules import can_free_scout_flies, can_fight
 
 
-def build_regions(level_name: str, player: int, multiworld: MultiWorld) -> List[JakAndDaxterRegion]:
+def build_regions(level_name: str, multiworld: MultiWorld, options: JakAndDaxterOptions, player: int) -> List[JakAndDaxterRegion]:
 
     # Just the starting area.
     main_area = JakAndDaxterRegion("Main Area", player, multiworld, level_name, 4)

--- a/worlds/jakanddaxter/regs/LostPrecursorCityRegions.py
+++ b/worlds/jakanddaxter/regs/LostPrecursorCityRegions.py
@@ -135,8 +135,11 @@ def build_regions(level_name: str, multiworld: MultiWorld, options: JakAndDaxter
 
         bundle_size = options.level_orbsanity_bundle_size.value
         bundle_count = int(200 / bundle_size)
-        for bundle_id in range(bundle_count):
-            orbs.add_orb_locations(bundle_id, access_rule=lambda state, bundle=bundle_id:
+        for bundle_index in range(bundle_count):
+            orbs.add_orb_locations(7,
+                                   bundle_index,
+                                   bundle_size,
+                                   access_rule=lambda state, bundle=bundle_index:
                                    can_reach_orbs(state, player, multiworld, options, level_name)
                                    >= (bundle_size * (bundle + 1)))
         multiworld.regions.append(orbs)

--- a/worlds/jakanddaxter/regs/MistyIslandRegions.py
+++ b/worlds/jakanddaxter/regs/MistyIslandRegions.py
@@ -121,8 +121,11 @@ def build_regions(level_name: str, multiworld: MultiWorld, options: JakAndDaxter
 
         bundle_size = options.level_orbsanity_bundle_size.value
         bundle_count = int(150 / bundle_size)
-        for bundle_id in range(bundle_count):
-            orbs.add_orb_locations(bundle_id, access_rule=lambda state, bundle=bundle_id:
+        for bundle_index in range(bundle_count):
+            orbs.add_orb_locations(4,
+                                   bundle_index,
+                                   bundle_size,
+                                   access_rule=lambda state, bundle=bundle_index:
                                    can_reach_orbs(state, player, multiworld, options, level_name)
                                    >= (bundle_size * (bundle + 1)))
         multiworld.regions.append(orbs)

--- a/worlds/jakanddaxter/regs/MistyIslandRegions.py
+++ b/worlds/jakanddaxter/regs/MistyIslandRegions.py
@@ -1,10 +1,11 @@
 from typing import List
 from BaseClasses import CollectionState, MultiWorld
 from .RegionBase import JakAndDaxterRegion
+from .. import JakAndDaxterOptions
 from ..Rules import can_free_scout_flies, can_fight
 
 
-def build_regions(level_name: str, player: int, multiworld: MultiWorld) -> List[JakAndDaxterRegion]:
+def build_regions(level_name: str, multiworld: MultiWorld, options: JakAndDaxterOptions, player: int) -> List[JakAndDaxterRegion]:
     
     main_area = JakAndDaxterRegion("Main Area", player, multiworld, level_name, 9)
 

--- a/worlds/jakanddaxter/regs/MistyIslandRegions.py
+++ b/worlds/jakanddaxter/regs/MistyIslandRegions.py
@@ -2,7 +2,7 @@ from typing import List
 from BaseClasses import CollectionState, MultiWorld
 from .RegionBase import JakAndDaxterRegion
 from .. import JakAndDaxterOptions
-from ..Rules import can_free_scout_flies, can_fight
+from ..Rules import can_free_scout_flies, can_fight, can_reach_orbs
 
 
 def build_regions(level_name: str, multiworld: MultiWorld, options: JakAndDaxterOptions, player: int) -> List[JakAndDaxterRegion]:
@@ -113,5 +113,19 @@ def build_regions(level_name: str, multiworld: MultiWorld, options: JakAndDaxter
     multiworld.regions.append(upper_approach)
     multiworld.regions.append(lower_approach)
     multiworld.regions.append(arena)
+
+    # If Per-Level Orbsanity is enabled, build the special Orbsanity Region. This is a virtual region always
+    # accessible to Main Area. The Locations within are automatically checked when you collect enough orbs.
+    if options.enable_orbsanity.value == 1:
+        orbs = JakAndDaxterRegion("Orbsanity", player, multiworld, level_name)
+
+        bundle_size = options.level_orbsanity_bundle_size.value
+        bundle_count = int(150 / bundle_size)
+        for bundle_id in range(bundle_count):
+            orbs.add_orb_locations(bundle_id, access_rule=lambda state, bundle=bundle_id:
+                                   can_reach_orbs(state, player, multiworld, options, level_name)
+                                   >= (bundle_size * (bundle + 1)))
+        multiworld.regions.append(orbs)
+        main_area.connect(orbs)
 
     return [main_area]

--- a/worlds/jakanddaxter/regs/MountainPassRegions.py
+++ b/worlds/jakanddaxter/regs/MountainPassRegions.py
@@ -1,10 +1,11 @@
 from typing import List
 from BaseClasses import CollectionState, MultiWorld
 from .RegionBase import JakAndDaxterRegion
+from .. import JakAndDaxterOptions
 from ..locs import ScoutLocations as Scouts
 
 
-def build_regions(level_name: str, player: int, multiworld: MultiWorld) -> List[JakAndDaxterRegion]:
+def build_regions(level_name: str, multiworld: MultiWorld, options: JakAndDaxterOptions, player: int) -> List[JakAndDaxterRegion]:
 
     # This is basically just Klaww.
     main_area = JakAndDaxterRegion("Main Area", player, multiworld, level_name, 0)

--- a/worlds/jakanddaxter/regs/MountainPassRegions.py
+++ b/worlds/jakanddaxter/regs/MountainPassRegions.py
@@ -39,8 +39,11 @@ def build_regions(level_name: str, multiworld: MultiWorld, options: JakAndDaxter
 
         bundle_size = options.level_orbsanity_bundle_size.value
         bundle_count = int(50 / bundle_size)
-        for bundle_id in range(bundle_count):
-            orbs.add_orb_locations(bundle_id, access_rule=lambda state, bundle=bundle_id:
+        for bundle_index in range(bundle_count):
+            orbs.add_orb_locations(10,
+                                   bundle_index,
+                                   bundle_size,
+                                   access_rule=lambda state, bundle=bundle_index:
                                    can_reach_orbs(state, player, multiworld, options, level_name)
                                    >= (bundle_size * (bundle + 1)))
         multiworld.regions.append(orbs)

--- a/worlds/jakanddaxter/regs/PrecursorBasinRegions.py
+++ b/worlds/jakanddaxter/regs/PrecursorBasinRegions.py
@@ -1,10 +1,11 @@
 from typing import List
 from BaseClasses import CollectionState, MultiWorld
 from .RegionBase import JakAndDaxterRegion
+from .. import JakAndDaxterOptions
 from ..locs import CellLocations as Cells, ScoutLocations as Scouts
 
 
-def build_regions(level_name: str, player: int, multiworld: MultiWorld) -> List[JakAndDaxterRegion]:
+def build_regions(level_name: str, multiworld: MultiWorld, options: JakAndDaxterOptions, player: int) -> List[JakAndDaxterRegion]:
 
     main_area = JakAndDaxterRegion("Main Area", player, multiworld, level_name, 200)
 

--- a/worlds/jakanddaxter/regs/PrecursorBasinRegions.py
+++ b/worlds/jakanddaxter/regs/PrecursorBasinRegions.py
@@ -2,6 +2,7 @@ from typing import List
 from BaseClasses import CollectionState, MultiWorld
 from .RegionBase import JakAndDaxterRegion
 from .. import JakAndDaxterOptions
+from ..Rules import can_reach_orbs
 from ..locs import CellLocations as Cells, ScoutLocations as Scouts
 
 
@@ -14,5 +15,19 @@ def build_regions(level_name: str, multiworld: MultiWorld, options: JakAndDaxter
     main_area.add_fly_locations(Scouts.locPB_scoutTable.keys())
 
     multiworld.regions.append(main_area)
+
+    # If Per-Level Orbsanity is enabled, build the special Orbsanity Region. This is a virtual region always
+    # accessible to Main Area. The Locations within are automatically checked when you collect enough orbs.
+    if options.enable_orbsanity.value == 1:
+        orbs = JakAndDaxterRegion("Orbsanity", player, multiworld, level_name)
+
+        bundle_size = options.level_orbsanity_bundle_size.value
+        bundle_count = int(200 / bundle_size)
+        for bundle_id in range(bundle_count):
+            orbs.add_orb_locations(bundle_id, access_rule=lambda state, bundle=bundle_id:
+                                   can_reach_orbs(state, player, multiworld, options, level_name)
+                                   >= (bundle_size * (bundle + 1)))
+        multiworld.regions.append(orbs)
+        main_area.connect(orbs)
 
     return [main_area]

--- a/worlds/jakanddaxter/regs/PrecursorBasinRegions.py
+++ b/worlds/jakanddaxter/regs/PrecursorBasinRegions.py
@@ -23,8 +23,11 @@ def build_regions(level_name: str, multiworld: MultiWorld, options: JakAndDaxter
 
         bundle_size = options.level_orbsanity_bundle_size.value
         bundle_count = int(200 / bundle_size)
-        for bundle_id in range(bundle_count):
-            orbs.add_orb_locations(bundle_id, access_rule=lambda state, bundle=bundle_id:
+        for bundle_index in range(bundle_count):
+            orbs.add_orb_locations(9,
+                                   bundle_index,
+                                   bundle_size,
+                                   access_rule=lambda state, bundle=bundle_index:
                                    can_reach_orbs(state, player, multiworld, options, level_name)
                                    >= (bundle_size * (bundle + 1)))
         multiworld.regions.append(orbs)

--- a/worlds/jakanddaxter/regs/RegionBase.py
+++ b/worlds/jakanddaxter/regs/RegionBase.py
@@ -32,7 +32,8 @@ class JakAndDaxterRegion(Region):
         Converts Game ID's to AP ID's for you.
         """
         for loc in locations:
-            self.add_jak_locations(Cells.to_ap_id(loc), access_rule)
+            ap_id = Cells.to_ap_id(loc)
+            self.add_jak_locations(ap_id, location_table[ap_id], access_rule)
 
     def add_fly_locations(self, locations: List[int], access_rule: Callable = None):
         """
@@ -40,7 +41,8 @@ class JakAndDaxterRegion(Region):
         Converts Game ID's to AP ID's for you.
         """
         for loc in locations:
-            self.add_jak_locations(Scouts.to_ap_id(loc), access_rule)
+            ap_id = Scouts.to_ap_id(loc)
+            self.add_jak_locations(ap_id, location_table[ap_id], access_rule)
 
     def add_special_locations(self, locations: List[int], access_rule: Callable = None):
         """
@@ -50,29 +52,32 @@ class JakAndDaxterRegion(Region):
         Power Cell Locations, so you get 2 unlocks for these rather than 1.
         """
         for loc in locations:
-            self.add_jak_locations(Specials.to_ap_id(loc), access_rule)
+            ap_id = Specials.to_ap_id(loc)
+            self.add_jak_locations(ap_id, location_table[ap_id], access_rule)
 
-    def add_cache_locations(self, locations: List[int], access_rule: Callable = None):
+    def add_cache_locations(self, locations: List[int],  access_rule: Callable = None):
         """
         Adds an Orb Cache Location to this region with the given access rule.
         Converts Game ID's to AP ID's for you.
         """
         for loc in locations:
-            self.add_jak_locations(Caches.to_ap_id(loc), access_rule)
+            ap_id = Caches.to_ap_id(loc)
+            self.add_jak_locations(ap_id, location_table[ap_id], access_rule)
 
     def add_orb_locations(self, locations: List[int], access_rule: Callable = None):
         """
-        Adds an Orb Location to this region with the given access rule.
+        Adds an Orb Location to this region with the given access rule. Used only when Orbsanity is enabled.
         Converts Game ID's to AP ID's for you.
         """
         for loc in locations:
-            self.add_jak_locations(Orbs.to_ap_id(loc), access_rule)
+            ap_id = Orbs.to_ap_id(loc)
+            self.add_jak_locations(ap_id, f"{self.name} Orb Bundle {loc + 1}", access_rule)
 
-    def add_jak_locations(self, ap_id: int, access_rule: Callable = None):
+    def add_jak_locations(self, ap_id: int, name: str, access_rule: Callable = None):
         """
         Helper function to add Locations. Not to be used directly.
         """
-        location = JakAndDaxterLocation(self.player, location_table[ap_id], ap_id, self)
+        location = JakAndDaxterLocation(self.player, name, ap_id, self)
         if access_rule:
             location.access_rule = access_rule
         self.locations.append(location)

--- a/worlds/jakanddaxter/regs/RegionBase.py
+++ b/worlds/jakanddaxter/regs/RegionBase.py
@@ -69,10 +69,10 @@ class JakAndDaxterRegion(Region):
         Adds Orb Bundle Locations to this region equal to `bundle_count`. Used only when Per-Level Orbsanity is enabled.
         The orb factory class will handle AP ID enumeration.
         """
-        bundle_address = Orbs.create_address(level_index, bundle_index, bundle_size)
+        bundle_address = Orbs.create_address(level_index, bundle_index)
         location = JakAndDaxterLocation(self.player,
                                         f"{self.level_name} Orb Bundle {bundle_index + 1}".strip(),
-                                        bundle_address,
+                                        Orbs.to_ap_id(bundle_address),
                                         self)
         if access_rule:
             location.access_rule = access_rule

--- a/worlds/jakanddaxter/regs/RegionBase.py
+++ b/worlds/jakanddaxter/regs/RegionBase.py
@@ -55,7 +55,7 @@ class JakAndDaxterRegion(Region):
             ap_id = Specials.to_ap_id(loc)
             self.add_jak_locations(ap_id, location_table[ap_id], access_rule)
 
-    def add_cache_locations(self, locations: List[int],  access_rule: Callable = None):
+    def add_cache_locations(self, locations: List[int], access_rule: Callable = None):
         """
         Adds an Orb Cache Location to this region with the given access rule.
         Converts Game ID's to AP ID's for you.
@@ -64,14 +64,19 @@ class JakAndDaxterRegion(Region):
             ap_id = Caches.to_ap_id(loc)
             self.add_jak_locations(ap_id, location_table[ap_id], access_rule)
 
-    def add_orb_locations(self, locations: List[int], access_rule: Callable = None):
+    def add_orb_locations(self, bundle_id: int, access_rule: Callable = None):
         """
-        Adds an Orb Location to this region with the given access rule. Used only when Orbsanity is enabled.
-        Converts Game ID's to AP ID's for you.
+        Adds Orb Bundle Locations to this region equal to `bundle_count`. Used only when Per-Level Orbsanity is enabled.
+        The orb factory class will handle AP ID enumeration.
         """
-        for loc in locations:
-            ap_id = Orbs.to_ap_id(loc)
-            self.add_jak_locations(ap_id, f"{self.name} Orb Bundle {loc + 1}", access_rule)
+        bundle_address = Orbs.orb_factory.make_new_address()
+        location = JakAndDaxterLocation(self.player,
+                                        f"{self.level_name} Orb Bundle {bundle_id + 1}".strip(),
+                                        bundle_address,
+                                        self)
+        if access_rule:
+            location.access_rule = access_rule
+        self.locations.append(location)
 
     def add_jak_locations(self, ap_id: int, name: str, access_rule: Callable = None):
         """

--- a/worlds/jakanddaxter/regs/RegionBase.py
+++ b/worlds/jakanddaxter/regs/RegionBase.py
@@ -3,7 +3,8 @@ from BaseClasses import MultiWorld, Region
 from ..GameID import jak1_name
 from ..JakAndDaxterOptions import JakAndDaxterOptions
 from ..Locations import JakAndDaxterLocation, location_table
-from ..locs import (CellLocations as Cells,
+from ..locs import (OrbLocations as Orbs,
+                    CellLocations as Cells,
                     ScoutLocations as Scouts,
                     SpecialLocations as Specials,
                     OrbCacheLocations as Caches)
@@ -58,6 +59,14 @@ class JakAndDaxterRegion(Region):
         """
         for loc in locations:
             self.add_jak_locations(Caches.to_ap_id(loc), access_rule)
+
+    def add_orb_locations(self, locations: List[int], access_rule: Callable = None):
+        """
+        Adds an Orb Location to this region with the given access rule.
+        Converts Game ID's to AP ID's for you.
+        """
+        for loc in locations:
+            self.add_jak_locations(Orbs.to_ap_id(loc), access_rule)
 
     def add_jak_locations(self, ap_id: int, access_rule: Callable = None):
         """

--- a/worlds/jakanddaxter/regs/RegionBase.py
+++ b/worlds/jakanddaxter/regs/RegionBase.py
@@ -64,14 +64,14 @@ class JakAndDaxterRegion(Region):
             ap_id = Caches.to_ap_id(loc)
             self.add_jak_locations(ap_id, location_table[ap_id], access_rule)
 
-    def add_orb_locations(self, bundle_id: int, access_rule: Callable = None):
+    def add_orb_locations(self, level_index: int, bundle_index: int, bundle_size: int, access_rule: Callable = None):
         """
         Adds Orb Bundle Locations to this region equal to `bundle_count`. Used only when Per-Level Orbsanity is enabled.
         The orb factory class will handle AP ID enumeration.
         """
-        bundle_address = Orbs.orb_factory.make_new_address()
+        bundle_address = Orbs.create_address(level_index, bundle_index, bundle_size)
         location = JakAndDaxterLocation(self.player,
-                                        f"{self.level_name} Orb Bundle {bundle_id + 1}".strip(),
+                                        f"{self.level_name} Orb Bundle {bundle_index + 1}".strip(),
                                         bundle_address,
                                         self)
         if access_rule:

--- a/worlds/jakanddaxter/regs/RockVillageRegions.py
+++ b/worlds/jakanddaxter/regs/RockVillageRegions.py
@@ -34,8 +34,9 @@ def build_regions(level_name: str, multiworld: MultiWorld, options: JakAndDaxter
     orb_cache.add_cache_locations([10945], access_rule=lambda state:
                                   (state.has("Roll", player) and state.has("Roll Jump", player)))
 
+    # Fly here can be gotten with Yellow Eco from Boggy, goggles, and no extra movement options (see fly ID 43).
     pontoon_bridge = JakAndDaxterRegion("Pontoon Bridge", player, multiworld, level_name, 7)
-    pontoon_bridge.add_fly_locations([393292], access_rule=lambda state: can_free_scout_flies(state, player))
+    pontoon_bridge.add_fly_locations([393292])
 
     klaww_cliff = JakAndDaxterRegion("Klaww's Cliff", player, multiworld, level_name, 0)
 

--- a/worlds/jakanddaxter/regs/RockVillageRegions.py
+++ b/worlds/jakanddaxter/regs/RockVillageRegions.py
@@ -1,23 +1,24 @@
 from typing import List
 from BaseClasses import CollectionState, MultiWorld
 from .RegionBase import JakAndDaxterRegion
+from .. import JakAndDaxterOptions
 from ..Rules import can_free_scout_flies, can_trade
 
 
-def build_regions(level_name: str, player: int, multiworld: MultiWorld) -> List[JakAndDaxterRegion]:
+def build_regions(level_name: str, multiworld: MultiWorld, options: JakAndDaxterOptions, player: int) -> List[JakAndDaxterRegion]:
 
     # This includes most of the area surrounding LPC as well, for orb_count purposes. You can swim and single jump.
     main_area = JakAndDaxterRegion("Main Area", player, multiworld, level_name, 23)
     main_area.add_cell_locations([31], access_rule=lambda state:
-                                 can_trade(state, player, multiworld, 1530))
+                                 can_trade(state, player, multiworld, options, 1530))
     main_area.add_cell_locations([32], access_rule=lambda state:
-                                 can_trade(state, player, multiworld, 1530))
+                                 can_trade(state, player, multiworld, options, 1530))
     main_area.add_cell_locations([33], access_rule=lambda state:
-                                 can_trade(state, player, multiworld, 1530))
+                                 can_trade(state, player, multiworld, options, 1530))
     main_area.add_cell_locations([34], access_rule=lambda state:
-                                 can_trade(state, player, multiworld, 1530))
+                                 can_trade(state, player, multiworld, options, 1530))
     main_area.add_cell_locations([35], access_rule=lambda state:
-                                 can_trade(state, player, multiworld, 1530, 34))
+                                 can_trade(state, player, multiworld, options, 1530, 34))
 
     # These 2 scout fly boxes can be broken by running with nearby blue eco.
     main_area.add_fly_locations([196684, 262220])

--- a/worlds/jakanddaxter/regs/RockVillageRegions.py
+++ b/worlds/jakanddaxter/regs/RockVillageRegions.py
@@ -2,7 +2,7 @@ from typing import List
 from BaseClasses import CollectionState, MultiWorld
 from .RegionBase import JakAndDaxterRegion
 from .. import JakAndDaxterOptions
-from ..Rules import can_free_scout_flies, can_trade
+from ..Rules import can_free_scout_flies, can_trade, can_reach_orbs
 
 
 def build_regions(level_name: str, multiworld: MultiWorld, options: JakAndDaxterOptions, player: int) -> List[JakAndDaxterRegion]:
@@ -59,6 +59,20 @@ def build_regions(level_name: str, multiworld: MultiWorld, options: JakAndDaxter
     multiworld.regions.append(orb_cache)
     multiworld.regions.append(pontoon_bridge)
     multiworld.regions.append(klaww_cliff)
+
+    # If Per-Level Orbsanity is enabled, build the special Orbsanity Region. This is a virtual region always
+    # accessible to Main Area. The Locations within are automatically checked when you collect enough orbs.
+    if options.enable_orbsanity.value == 1:
+        orbs = JakAndDaxterRegion("Orbsanity", player, multiworld, level_name)
+
+        bundle_size = options.level_orbsanity_bundle_size.value
+        bundle_count = int(50 / bundle_size)
+        for bundle_id in range(bundle_count):
+            orbs.add_orb_locations(bundle_id, access_rule=lambda state, bundle=bundle_id:
+                                   can_reach_orbs(state, player, multiworld, options, level_name)
+                                   >= (bundle_size * (bundle + 1)))
+        multiworld.regions.append(orbs)
+        main_area.connect(orbs)
 
     # Return klaww_cliff required for inter-level connections.
     return [main_area, pontoon_bridge, klaww_cliff]

--- a/worlds/jakanddaxter/regs/RockVillageRegions.py
+++ b/worlds/jakanddaxter/regs/RockVillageRegions.py
@@ -67,8 +67,11 @@ def build_regions(level_name: str, multiworld: MultiWorld, options: JakAndDaxter
 
         bundle_size = options.level_orbsanity_bundle_size.value
         bundle_count = int(50 / bundle_size)
-        for bundle_id in range(bundle_count):
-            orbs.add_orb_locations(bundle_id, access_rule=lambda state, bundle=bundle_id:
+        for bundle_index in range(bundle_count):
+            orbs.add_orb_locations(6,
+                                   bundle_index,
+                                   bundle_size,
+                                   access_rule=lambda state, bundle=bundle_index:
                                    can_reach_orbs(state, player, multiworld, options, level_name)
                                    >= (bundle_size * (bundle + 1)))
         multiworld.regions.append(orbs)

--- a/worlds/jakanddaxter/regs/SandoverVillageRegions.py
+++ b/worlds/jakanddaxter/regs/SandoverVillageRegions.py
@@ -76,8 +76,11 @@ def build_regions(level_name: str, multiworld: MultiWorld, options: JakAndDaxter
 
         bundle_size = options.level_orbsanity_bundle_size.value
         bundle_count = int(50 / bundle_size)
-        for bundle_id in range(bundle_count):
-            orbs.add_orb_locations(bundle_id, access_rule=lambda state, bundle=bundle_id:
+        for bundle_index in range(bundle_count):
+            orbs.add_orb_locations(1,
+                                   bundle_index,
+                                   bundle_size,
+                                   access_rule=lambda state, bundle=bundle_index:
                                    can_reach_orbs(state, player, multiworld, options, level_name)
                                    >= (bundle_size * (bundle + 1)))
         multiworld.regions.append(orbs)

--- a/worlds/jakanddaxter/regs/SandoverVillageRegions.py
+++ b/worlds/jakanddaxter/regs/SandoverVillageRegions.py
@@ -1,19 +1,20 @@
 from typing import List
 from BaseClasses import CollectionState, MultiWorld
 from .RegionBase import JakAndDaxterRegion
+from .. import JakAndDaxterOptions
 from ..Rules import can_free_scout_flies, can_trade
 
 
-def build_regions(level_name: str, player: int, multiworld: MultiWorld) -> List[JakAndDaxterRegion]:
+def build_regions(level_name: str, multiworld: MultiWorld, options: JakAndDaxterOptions, player: int) -> List[JakAndDaxterRegion]:
 
     main_area = JakAndDaxterRegion("Main Area", player, multiworld, level_name, 26)
 
     # Yakows requires no combat.
     main_area.add_cell_locations([10])
     main_area.add_cell_locations([11], access_rule=lambda state:
-                                 can_trade(state, player, multiworld, 1530))
+                                 can_trade(state, player, multiworld, options, 1530))
     main_area.add_cell_locations([12], access_rule=lambda state:
-                                 can_trade(state, player, multiworld, 1530))
+                                 can_trade(state, player, multiworld, options, 1530))
 
     # These 4 scout fly boxes can be broken by running with all the blue eco from Sentinel Beach.
     main_area.add_fly_locations([262219, 327755, 131147, 65611])
@@ -32,9 +33,9 @@ def build_regions(level_name: str, player: int, multiworld: MultiWorld) -> List[
 
     oracle_platforms = JakAndDaxterRegion("Oracle Platforms", player, multiworld, level_name, 6)
     oracle_platforms.add_cell_locations([13], access_rule=lambda state:
-                                        can_trade(state, player, multiworld, 1530))
+                                        can_trade(state, player, multiworld, options, 1530))
     oracle_platforms.add_cell_locations([14], access_rule=lambda state:
-                                        can_trade(state, player, multiworld, 1530, 13))
+                                        can_trade(state, player, multiworld, options, 1530, 13))
     oracle_platforms.add_fly_locations([393291], access_rule=lambda state:
                                        can_free_scout_flies(state, player))
 

--- a/worlds/jakanddaxter/regs/SandoverVillageRegions.py
+++ b/worlds/jakanddaxter/regs/SandoverVillageRegions.py
@@ -2,7 +2,7 @@ from typing import List
 from BaseClasses import CollectionState, MultiWorld
 from .RegionBase import JakAndDaxterRegion
 from .. import JakAndDaxterOptions
-from ..Rules import can_free_scout_flies, can_trade
+from ..Rules import can_free_scout_flies, can_trade, can_reach_orbs
 
 
 def build_regions(level_name: str, multiworld: MultiWorld, options: JakAndDaxterOptions, player: int) -> List[JakAndDaxterRegion]:
@@ -68,5 +68,19 @@ def build_regions(level_name: str, multiworld: MultiWorld, options: JakAndDaxter
     multiworld.regions.append(orb_cache_cliff)
     multiworld.regions.append(yakow_cliff)
     multiworld.regions.append(oracle_platforms)
+
+    # If Per-Level Orbsanity is enabled, build the special Orbsanity Region. This is a virtual region always
+    # accessible to Main Area. The Locations within are automatically checked when you collect enough orbs.
+    if options.enable_orbsanity.value == 1:
+        orbs = JakAndDaxterRegion("Orbsanity", player, multiworld, level_name)
+
+        bundle_size = options.level_orbsanity_bundle_size.value
+        bundle_count = int(50 / bundle_size)
+        for bundle_id in range(bundle_count):
+            orbs.add_orb_locations(bundle_id, access_rule=lambda state, bundle=bundle_id:
+                                   can_reach_orbs(state, player, multiworld, options, level_name)
+                                   >= (bundle_size * (bundle + 1)))
+        multiworld.regions.append(orbs)
+        main_area.connect(orbs)
 
     return [main_area]

--- a/worlds/jakanddaxter/regs/SentinelBeachRegions.py
+++ b/worlds/jakanddaxter/regs/SentinelBeachRegions.py
@@ -90,8 +90,11 @@ def build_regions(level_name: str, multiworld: MultiWorld, options: JakAndDaxter
 
         bundle_size = options.level_orbsanity_bundle_size.value
         bundle_count = int(150 / bundle_size)
-        for bundle_id in range(bundle_count):
-            orbs.add_orb_locations(bundle_id, access_rule=lambda state, bundle=bundle_id:
+        for bundle_index in range(bundle_count):
+            orbs.add_orb_locations(2,
+                                   bundle_index,
+                                   bundle_size,
+                                   access_rule=lambda state, bundle=bundle_index:
                                    can_reach_orbs(state, player, multiworld, options, level_name)
                                    >= (bundle_size * (bundle + 1)))
         multiworld.regions.append(orbs)

--- a/worlds/jakanddaxter/regs/SentinelBeachRegions.py
+++ b/worlds/jakanddaxter/regs/SentinelBeachRegions.py
@@ -2,7 +2,7 @@ from typing import List
 from BaseClasses import CollectionState, MultiWorld
 from .RegionBase import JakAndDaxterRegion
 from .. import JakAndDaxterOptions
-from ..Rules import can_free_scout_flies, can_fight
+from ..Rules import can_free_scout_flies, can_fight, can_reach_orbs
 
 
 def build_regions(level_name: str, multiworld: MultiWorld, options: JakAndDaxterOptions, player: int) -> List[JakAndDaxterRegion]:
@@ -82,5 +82,19 @@ def build_regions(level_name: str, multiworld: MultiWorld, options: JakAndDaxter
     multiworld.regions.append(green_ridge)
     multiworld.regions.append(blue_ridge)
     multiworld.regions.append(cannon_tower)
+
+    # If Per-Level Orbsanity is enabled, build the special Orbsanity Region. This is a virtual region always
+    # accessible to Main Area. The Locations within are automatically checked when you collect enough orbs.
+    if options.enable_orbsanity.value == 1:
+        orbs = JakAndDaxterRegion("Orbsanity", player, multiworld, level_name)
+
+        bundle_size = options.level_orbsanity_bundle_size.value
+        bundle_count = int(150 / bundle_size)
+        for bundle_id in range(bundle_count):
+            orbs.add_orb_locations(bundle_id, access_rule=lambda state, bundle=bundle_id:
+                                   can_reach_orbs(state, player, multiworld, options, level_name)
+                                   >= (bundle_size * (bundle + 1)))
+        multiworld.regions.append(orbs)
+        main_area.connect(orbs)
 
     return [main_area]

--- a/worlds/jakanddaxter/regs/SentinelBeachRegions.py
+++ b/worlds/jakanddaxter/regs/SentinelBeachRegions.py
@@ -1,10 +1,11 @@
 from typing import List
 from BaseClasses import CollectionState, MultiWorld
 from .RegionBase import JakAndDaxterRegion
+from .. import JakAndDaxterOptions
 from ..Rules import can_free_scout_flies, can_fight
 
 
-def build_regions(level_name: str, player: int, multiworld: MultiWorld) -> List[JakAndDaxterRegion]:
+def build_regions(level_name: str, multiworld: MultiWorld, options: JakAndDaxterOptions, player: int) -> List[JakAndDaxterRegion]:
 
     main_area = JakAndDaxterRegion("Main Area", player, multiworld, level_name, 128)
     main_area.add_cell_locations([18, 21, 22])

--- a/worlds/jakanddaxter/regs/SnowyMountainRegions.py
+++ b/worlds/jakanddaxter/regs/SnowyMountainRegions.py
@@ -2,7 +2,7 @@ from typing import List
 from BaseClasses import CollectionState, MultiWorld
 from .RegionBase import JakAndDaxterRegion
 from .. import JakAndDaxterOptions
-from ..Rules import can_free_scout_flies, can_fight
+from ..Rules import can_free_scout_flies, can_fight, can_reach_orbs
 
 
 # God help me... here we go.
@@ -189,5 +189,19 @@ def build_regions(level_name: str, multiworld: MultiWorld, options: JakAndDaxter
     multiworld.regions.append(fort_interior_caches)
     multiworld.regions.append(fort_interior_base)
     multiworld.regions.append(fort_interior_course_end)
+
+    # If Per-Level Orbsanity is enabled, build the special Orbsanity Region. This is a virtual region always
+    # accessible to Main Area. The Locations within are automatically checked when you collect enough orbs.
+    if options.enable_orbsanity.value == 1:
+        orbs = JakAndDaxterRegion("Orbsanity", player, multiworld, level_name)
+
+        bundle_size = options.level_orbsanity_bundle_size.value
+        bundle_count = int(200 / bundle_size)
+        for bundle_id in range(bundle_count):
+            orbs.add_orb_locations(bundle_id, access_rule=lambda state, bundle=bundle_id:
+                                   can_reach_orbs(state, player, multiworld, options, level_name)
+                                   >= (bundle_size * (bundle + 1)))
+        multiworld.regions.append(orbs)
+        main_area.connect(orbs)
 
     return [main_area]

--- a/worlds/jakanddaxter/regs/SnowyMountainRegions.py
+++ b/worlds/jakanddaxter/regs/SnowyMountainRegions.py
@@ -1,11 +1,12 @@
 from typing import List
 from BaseClasses import CollectionState, MultiWorld
 from .RegionBase import JakAndDaxterRegion
+from .. import JakAndDaxterOptions
 from ..Rules import can_free_scout_flies, can_fight
 
 
 # God help me... here we go.
-def build_regions(level_name: str, player: int, multiworld: MultiWorld) -> List[JakAndDaxterRegion]:
+def build_regions(level_name: str, multiworld: MultiWorld, options: JakAndDaxterOptions, player: int) -> List[JakAndDaxterRegion]:
 
     # We need a few helper functions.
     def can_cross_main_gap(state: CollectionState, p: int) -> bool:

--- a/worlds/jakanddaxter/regs/SnowyMountainRegions.py
+++ b/worlds/jakanddaxter/regs/SnowyMountainRegions.py
@@ -197,8 +197,11 @@ def build_regions(level_name: str, multiworld: MultiWorld, options: JakAndDaxter
 
         bundle_size = options.level_orbsanity_bundle_size.value
         bundle_count = int(200 / bundle_size)
-        for bundle_id in range(bundle_count):
-            orbs.add_orb_locations(bundle_id, access_rule=lambda state, bundle=bundle_id:
+        for bundle_index in range(bundle_count):
+            orbs.add_orb_locations(12,
+                                   bundle_index,
+                                   bundle_size,
+                                   access_rule=lambda state, bundle=bundle_index:
                                    can_reach_orbs(state, player, multiworld, options, level_name)
                                    >= (bundle_size * (bundle + 1)))
         multiworld.regions.append(orbs)

--- a/worlds/jakanddaxter/regs/SpiderCaveRegions.py
+++ b/worlds/jakanddaxter/regs/SpiderCaveRegions.py
@@ -115,8 +115,11 @@ def build_regions(level_name: str, multiworld: MultiWorld, options: JakAndDaxter
 
         bundle_size = options.level_orbsanity_bundle_size.value
         bundle_count = int(200 / bundle_size)
-        for bundle_id in range(bundle_count):
-            orbs.add_orb_locations(bundle_id, access_rule=lambda state, bundle=bundle_id:
+        for bundle_index in range(bundle_count):
+            orbs.add_orb_locations(13,
+                                   bundle_index,
+                                   bundle_size,
+                                   access_rule=lambda state, bundle=bundle_index:
                                    can_reach_orbs(state, player, multiworld, options, level_name)
                                    >= (bundle_size * (bundle + 1)))
         multiworld.regions.append(orbs)

--- a/worlds/jakanddaxter/regs/SpiderCaveRegions.py
+++ b/worlds/jakanddaxter/regs/SpiderCaveRegions.py
@@ -2,7 +2,7 @@ from typing import List
 from BaseClasses import CollectionState, MultiWorld
 from .RegionBase import JakAndDaxterRegion
 from .. import JakAndDaxterOptions
-from ..Rules import can_free_scout_flies, can_fight
+from ..Rules import can_free_scout_flies, can_fight, can_reach_orbs
 
 
 def build_regions(level_name: str, multiworld: MultiWorld, options: JakAndDaxterOptions, player: int) -> List[JakAndDaxterRegion]:
@@ -107,5 +107,19 @@ def build_regions(level_name: str, multiworld: MultiWorld, options: JakAndDaxter
     multiworld.regions.append(pole_course)
     multiworld.regions.append(spider_tunnel)
     multiworld.regions.append(spider_tunnel_crates)
+
+    # If Per-Level Orbsanity is enabled, build the special Orbsanity Region. This is a virtual region always
+    # accessible to Main Area. The Locations within are automatically checked when you collect enough orbs.
+    if options.enable_orbsanity.value == 1:
+        orbs = JakAndDaxterRegion("Orbsanity", player, multiworld, level_name)
+
+        bundle_size = options.level_orbsanity_bundle_size.value
+        bundle_count = int(200 / bundle_size)
+        for bundle_id in range(bundle_count):
+            orbs.add_orb_locations(bundle_id, access_rule=lambda state, bundle=bundle_id:
+                                   can_reach_orbs(state, player, multiworld, options, level_name)
+                                   >= (bundle_size * (bundle + 1)))
+        multiworld.regions.append(orbs)
+        main_area.connect(orbs)
 
     return [main_area]

--- a/worlds/jakanddaxter/regs/SpiderCaveRegions.py
+++ b/worlds/jakanddaxter/regs/SpiderCaveRegions.py
@@ -1,10 +1,11 @@
 from typing import List
 from BaseClasses import CollectionState, MultiWorld
 from .RegionBase import JakAndDaxterRegion
+from .. import JakAndDaxterOptions
 from ..Rules import can_free_scout_flies, can_fight
 
 
-def build_regions(level_name: str, player: int, multiworld: MultiWorld) -> List[JakAndDaxterRegion]:
+def build_regions(level_name: str, multiworld: MultiWorld, options: JakAndDaxterOptions, player: int) -> List[JakAndDaxterRegion]:
 
     # A large amount of this area can be covered by single jump, floating platforms, web trampolines, and goggles.
     main_area = JakAndDaxterRegion("Main Area", player, multiworld, level_name, 63)

--- a/worlds/jakanddaxter/regs/VolcanicCraterRegions.py
+++ b/worlds/jakanddaxter/regs/VolcanicCraterRegions.py
@@ -1,26 +1,27 @@
 from typing import List
 from BaseClasses import CollectionState, MultiWorld
 from .RegionBase import JakAndDaxterRegion
+from .. import JakAndDaxterOptions
 from ..Rules import can_free_scout_flies, can_trade
 from ..locs import CellLocations as Cells, ScoutLocations as Scouts
 
 
-def build_regions(level_name: str, player: int, multiworld: MultiWorld) -> List[JakAndDaxterRegion]:
+def build_regions(level_name: str, multiworld: MultiWorld, options: JakAndDaxterOptions, player: int) -> List[JakAndDaxterRegion]:
 
     # No area is inaccessible in VC even with only running and jumping.
     main_area = JakAndDaxterRegion("Main Area", player, multiworld, level_name, 50)
     main_area.add_cell_locations([96], access_rule=lambda state:
-                                 can_trade(state, player, multiworld, 1530))
+                                 can_trade(state, player, multiworld, options, 1530))
     main_area.add_cell_locations([97], access_rule=lambda state:
-                                 can_trade(state, player, multiworld, 1530, 96))
+                                 can_trade(state, player, multiworld, options, 1530, 96))
     main_area.add_cell_locations([98], access_rule=lambda state:
-                                 can_trade(state, player, multiworld, 1530, 97))
+                                 can_trade(state, player, multiworld, options, 1530, 97))
     main_area.add_cell_locations([99], access_rule=lambda state:
-                                 can_trade(state, player, multiworld, 1530, 98))
+                                 can_trade(state, player, multiworld, options, 1530, 98))
     main_area.add_cell_locations([100], access_rule=lambda state:
-                                 can_trade(state, player, multiworld, 1530))
+                                 can_trade(state, player, multiworld, options, 1530))
     main_area.add_cell_locations([101], access_rule=lambda state:
-                                 can_trade(state, player, multiworld, 1530, 100))
+                                 can_trade(state, player, multiworld, options, 1530, 100))
 
     # Hidden Power Cell: you can carry yellow eco from Spider Cave just by running and jumping
     # and using your Goggles to shoot the box (you do not need Punch to shoot from FP mode).

--- a/worlds/jakanddaxter/regs/VolcanicCraterRegions.py
+++ b/worlds/jakanddaxter/regs/VolcanicCraterRegions.py
@@ -2,7 +2,7 @@ from typing import List
 from BaseClasses import CollectionState, MultiWorld
 from .RegionBase import JakAndDaxterRegion
 from .. import JakAndDaxterOptions
-from ..Rules import can_free_scout_flies, can_trade
+from ..Rules import can_free_scout_flies, can_trade, can_reach_orbs
 from ..locs import CellLocations as Cells, ScoutLocations as Scouts
 
 
@@ -35,5 +35,19 @@ def build_regions(level_name: str, multiworld: MultiWorld, options: JakAndDaxter
     main_area.add_special_locations([105])
 
     multiworld.regions.append(main_area)
+
+    # If Per-Level Orbsanity is enabled, build the special Orbsanity Region. This is a virtual region always
+    # accessible to Main Area. The Locations within are automatically checked when you collect enough orbs.
+    if options.enable_orbsanity.value == 1:
+        orbs = JakAndDaxterRegion("Orbsanity", player, multiworld, level_name)
+
+        bundle_size = options.level_orbsanity_bundle_size.value
+        bundle_count = int(50 / bundle_size)
+        for bundle_id in range(bundle_count):
+            orbs.add_orb_locations(bundle_id, access_rule=lambda state, bundle=bundle_id:
+                                   can_reach_orbs(state, player, multiworld, options, level_name)
+                                   >= (bundle_size * (bundle + 1)))
+        multiworld.regions.append(orbs)
+        main_area.connect(orbs)
 
     return [main_area]

--- a/worlds/jakanddaxter/regs/VolcanicCraterRegions.py
+++ b/worlds/jakanddaxter/regs/VolcanicCraterRegions.py
@@ -43,8 +43,11 @@ def build_regions(level_name: str, multiworld: MultiWorld, options: JakAndDaxter
 
         bundle_size = options.level_orbsanity_bundle_size.value
         bundle_count = int(50 / bundle_size)
-        for bundle_id in range(bundle_count):
-            orbs.add_orb_locations(bundle_id, access_rule=lambda state, bundle=bundle_id:
+        for bundle_index in range(bundle_count):
+            orbs.add_orb_locations(11,
+                                   bundle_index,
+                                   bundle_size,
+                                   access_rule=lambda state, bundle=bundle_index:
                                    can_reach_orbs(state, player, multiworld, options, level_name)
                                    >= (bundle_size * (bundle + 1)))
         multiworld.regions.append(orbs)


### PR DESCRIPTION
## What is this fixing or adding?
- Implements #9 .
- Fixed some values that display in different HUD modes.
  - Regular HUD shows Received values, alternate modes show Per-Level or Global _Checked_ values.
- Added Update instructions to the setup doc.
- Fixed error spam in text client while offline, when dying with Deathlink enabled.
- Fixed ability to Roll into a Crouch stance.
  - If you don't have Crouch and you Roll, Jak is forced to stand.

## How was this tested?
- Played through to Rock Village with multiple settings.
  - Orbsanity off, Orbsanity with Global 1 orb bundles, Orbsanity with Local 1 orb bundles, Orbsanity with Local 20 orb bundles.
- Generated multiple seeds to verify integrity of regions, ability to pay traders, etc.

## If this makes graphical changes, please attach screenshots.
![image](https://github.com/user-attachments/assets/c630e0fb-55a8-4cfb-8d40-db4f4b593432)
![image](https://github.com/user-attachments/assets/038dd7e2-be75-48aa-b20b-1e2186b16154)
![image](https://github.com/user-attachments/assets/2c8cc567-63ae-4a70-905f-1c22f0c4dc41)

