### PR TITLE
Finishing Touches

### DIFF
--- a/worlds/jakanddaxter/Client.py
+++ b/worlds/jakanddaxter/Client.py
@@ -10,6 +10,7 @@ from pymem.exception import ProcessNotFound, ProcessError
 import Utils
 from NetUtils import ClientStatus
 from CommonClient import ClientCommandProcessor, CommonContext, logger, server_loop, gui_enabled
+from .JakAndDaxterOptions import EnableOrbsanity
 
 from .GameID import jak1_name
 from .client.ReplClient import JakAndDaxterReplClient
@@ -110,9 +111,14 @@ class JakAndDaxterContext(CommonContext):
 
         if cmd == "Connected":
             slot_data = args["slot_data"]
-            if slot_data["enable_orbsanity"] == 1:
+            self.repl.setup_goals(slot_data["fire_canyon_cell_count"],
+                                  slot_data["mountain_pass_cell_count"],
+                                  slot_data["lava_tube_cell_count"],
+                                  slot_data["completion_condition"])
+
+            if slot_data["enable_orbsanity"] == EnableOrbsanity.option_per_level:
                 self.repl.setup_orbsanity(slot_data["enable_orbsanity"], slot_data["level_orbsanity_bundle_size"])
-            elif slot_data["enable_orbsanity"] == 2:
+            elif slot_data["enable_orbsanity"] == EnableOrbsanity.option_global:
                 self.repl.setup_orbsanity(slot_data["enable_orbsanity"], slot_data["global_orbsanity_bundle_size"])
             else:
                 self.repl.setup_orbsanity(slot_data["enable_orbsanity"], 1)

--- a/worlds/jakanddaxter/Client.py
+++ b/worlds/jakanddaxter/Client.py
@@ -85,8 +85,8 @@ class JakAndDaxterContext(CommonContext):
     def __init__(self, server_address: typing.Optional[str], password: typing.Optional[str]) -> None:
         self.repl = JakAndDaxterReplClient()
         self.memr = JakAndDaxterMemoryReader()
-        # self.memr.load_data()
         # self.repl.load_data()
+        # self.memr.load_data()
         super().__init__(server_address, password)
 
     def run_gui(self):
@@ -116,23 +116,21 @@ class JakAndDaxterContext(CommonContext):
                                   slot_data["lava_tube_cell_count"],
                                   slot_data["completion_condition"])
 
-            if slot_data["enable_orbsanity"] == EnableOrbsanity.option_per_level:
-                self.repl.setup_orbsanity(slot_data["enable_orbsanity"], slot_data["level_orbsanity_bundle_size"])
-            elif slot_data["enable_orbsanity"] == EnableOrbsanity.option_global:
-                self.repl.setup_orbsanity(slot_data["enable_orbsanity"], slot_data["global_orbsanity_bundle_size"])
+            orbsanity_option = slot_data["enable_orbsanity"]
+            if orbsanity_option == EnableOrbsanity.option_per_level:
+                self.repl.setup_orbsanity(orbsanity_option, slot_data["level_orbsanity_bundle_size"])
+            elif orbsanity_option == EnableOrbsanity.option_global:
+                self.repl.setup_orbsanity(orbsanity_option, slot_data["global_orbsanity_bundle_size"])
             else:
-                self.repl.setup_orbsanity(slot_data["enable_orbsanity"], 1)
+                self.repl.setup_orbsanity(orbsanity_option, 1)
 
         if cmd == "ReceivedItems":
             for index, item in enumerate(args["items"], start=args["index"]):
                 logger.debug(f"index: {str(index)}, item: {str(item)}")
                 self.repl.item_inbox[index] = item
-            self.memr.save_data()
-            self.repl.save_data()
 
     def on_print_json(self, args: dict) -> None:
-        relevant = args.get("type", None) in {"ItemSend"}
-        if relevant:
+        if "type" in args and args["type"] in {"ItemSend"}:
             item = args["item"]
             recipient = args["receiving"]
 

--- a/worlds/jakanddaxter/JakAndDaxterOptions.py
+++ b/worlds/jakanddaxter/JakAndDaxterOptions.py
@@ -1,5 +1,5 @@
 from dataclasses import dataclass
-from Options import Toggle, PerGameCommonOptions, Choice
+from Options import Toggle, PerGameCommonOptions, Choice, Range
 
 
 class EnableMoveRandomizer(Toggle):
@@ -66,9 +66,50 @@ class PerLevelOrbsanityBundleSize(Choice):
     default = 1
 
 
+class FireCanyonCellCount(Range):
+    """Set the number of orbs you need to cross Fire Canyon."""
+    display_name = "Fire Canyon Cell Count"
+    range_start = 0
+    range_end = 100
+    default = 20
+
+
+class MountainPassCellCount(Range):
+    """Set the number of orbs you need to reach Klaww and cross Mountain Pass."""
+    display_name = "Mountain Pass Cell Count"
+    range_start = 0
+    range_end = 100
+    default = 45
+
+
+class LavaTubeCellCount(Range):
+    """Set the number of orbs you need to cross Lava Tube."""
+    display_name = "Lava Tube Cell Count"
+    range_start = 0
+    range_end = 100
+    default = 72
+
+
+class CompletionCondition(Choice):
+    """Set the goal for completing the game."""
+    display_name = "Completion Condition"
+    option_cross_fire_canyon = 69
+    option_cross_mountain_pass = 87
+    option_cross_lava_tube = 89
+    option_defeat_dark_eco_plant = 6
+    option_defeat_klaww = 86
+    option_defeat_gol_and_maia = 112
+    option_open_100_cell_door = 106
+    default = 112
+
+
 @dataclass
 class JakAndDaxterOptions(PerGameCommonOptions):
     enable_move_randomizer: EnableMoveRandomizer
     enable_orbsanity: EnableOrbsanity
     global_orbsanity_bundle_size: GlobalOrbsanityBundleSize
     level_orbsanity_bundle_size: PerLevelOrbsanityBundleSize
+    fire_canyon_cell_count: FireCanyonCellCount
+    mountain_pass_cell_count: MountainPassCellCount
+    lava_tube_cell_count: LavaTubeCellCount
+    completion_condition: CompletionCondition

--- a/worlds/jakanddaxter/JakAndDaxterOptions.py
+++ b/worlds/jakanddaxter/JakAndDaxterOptions.py
@@ -99,7 +99,7 @@ class CompletionCondition(Choice):
     option_defeat_dark_eco_plant = 6
     option_defeat_klaww = 86
     option_defeat_gol_and_maia = 112
-    option_open_100_cell_door = 106
+    option_open_100_cell_door = 116
     default = 112
 
 

--- a/worlds/jakanddaxter/Regions.py
+++ b/worlds/jakanddaxter/Regions.py
@@ -1,5 +1,5 @@
 from BaseClasses import MultiWorld
-from .JakAndDaxterOptions import JakAndDaxterOptions
+from .JakAndDaxterOptions import JakAndDaxterOptions, EnableOrbsanity, CompletionCondition
 from .Items import item_table
 from .Rules import can_reach_orbs
 from .locs import (OrbLocations as Orbs,
@@ -44,7 +44,7 @@ def create_regions(multiworld: MultiWorld, options: JakAndDaxterOptions, player:
 
     # If Global Orbsanity is enabled, build the special Orbsanity Region. This is a virtual region always
     # accessible to Menu. The Locations within are automatically checked when you collect enough orbs.
-    if options.enable_orbsanity.value == 2:
+    if options.enable_orbsanity == EnableOrbsanity.option_global:
         orbs = JakAndDaxterRegion("Orbsanity", player, multiworld)
 
         bundle_size = options.global_orbsanity_bundle_size.value
@@ -64,7 +64,7 @@ def create_regions(multiworld: MultiWorld, options: JakAndDaxterOptions, player:
     # Build all regions. Include their intra-connecting Rules, their Locations, and their Location access rules.
     [gr] = GeyserRock.build_regions("Geyser Rock", multiworld, options, player)
     [sv] = SandoverVillage.build_regions("Sandover Village", multiworld, options, player)
-    [fj] = ForbiddenJungle.build_regions("Forbidden Jungle", multiworld, options, player)
+    [fj, fjp] = ForbiddenJungle.build_regions("Forbidden Jungle", multiworld, options, player)
     [sb] = SentinelBeach.build_regions("Sentinel Beach", multiworld, options, player)
     [mi] = MistyIsland.build_regions("Misty Island", multiworld, options, player)
     [fc] = FireCanyon.build_regions("Fire Canyon", multiworld, options, player)
@@ -77,7 +77,12 @@ def create_regions(multiworld: MultiWorld, options: JakAndDaxterOptions, player:
     [sc] = SpiderCave.build_regions("Spider Cave", multiworld, options, player)
     [sm] = SnowyMountain.build_regions("Snowy Mountain", multiworld, options, player)
     [lt] = LavaTube.build_regions("Lava Tube", multiworld, options, player)
-    [gmc, fb] = GolAndMaiasCitadel.build_regions("Gol and Maia's Citadel", multiworld, options, player)
+    [gmc, fb, fd] = GolAndMaiasCitadel.build_regions("Gol and Maia's Citadel", multiworld, options, player)
+
+    # Configurable counts of cells for connector levels.
+    fc_count = options.fire_canyon_cell_count.value
+    mp_count = options.mountain_pass_cell_count.value
+    lt_count = options.lava_tube_cell_count.value
 
     # Define the interconnecting rules.
     menu.connect(gr)
@@ -85,17 +90,36 @@ def create_regions(multiworld: MultiWorld, options: JakAndDaxterOptions, player:
     sv.connect(fj)
     sv.connect(sb)
     sv.connect(mi, rule=lambda state: state.has("Fisherman's Boat", player))
-    sv.connect(fc, rule=lambda state: state.has("Power Cell", player, 20))
+    sv.connect(fc, rule=lambda state: state.has("Power Cell", player, fc_count))  # Normally 20.
     fc.connect(rv)
     rv.connect(pb)
     rv.connect(lpc)
     rvp.connect(bs)  # rv->rvp/rvc connections defined internally by RockVillageRegions.
-    rvc.connect(mp, rule=lambda state: state.has("Power Cell", player, 45))
+    rvc.connect(mp, rule=lambda state: state.has("Power Cell", player, mp_count))  # Normally 45.
     mpr.connect(vc)  # mp->mpr connection defined internally by MountainPassRegions.
     vc.connect(sc)
     vc.connect(sm, rule=lambda state: state.has("Snowy Mountain Gondola", player))
-    vc.connect(lt, rule=lambda state: state.has("Power Cell", player, 72))
+    vc.connect(lt, rule=lambda state: state.has("Power Cell", player, lt_count))  # Normally 72.
     lt.connect(gmc)  # gmc->fb connection defined internally by GolAndMaiasCitadelRegions.
 
     # Finally, set the completion condition.
-    multiworld.completion_condition[player] = lambda state: state.can_reach(fb, "Region", player)
+    if options.completion_condition == CompletionCondition.option_cross_fire_canyon:
+        multiworld.completion_condition[player] = lambda state: state.can_reach(rv, "Region", player)
+
+    elif options.completion_condition == CompletionCondition.option_cross_mountain_pass:
+        multiworld.completion_condition[player] = lambda state: state.can_reach(vc, "Region", player)
+
+    elif options.completion_condition == CompletionCondition.option_cross_lava_tube:
+        multiworld.completion_condition[player] = lambda state: state.can_reach(gmc, "Region", player)
+
+    elif options.completion_condition == CompletionCondition.option_defeat_dark_eco_plant:
+        multiworld.completion_condition[player] = lambda state: state.can_reach(fjp, "Region", player)
+
+    elif options.completion_condition == CompletionCondition.option_defeat_klaww:
+        multiworld.completion_condition[player] = lambda state: state.can_reach(mp, "Region", player)
+
+    elif options.completion_condition == CompletionCondition.option_defeat_gol_and_maia:
+        multiworld.completion_condition[player] = lambda state: state.can_reach(fb, "Region", player)
+
+    elif options.completion_condition == CompletionCondition.option_open_100_cell_door:
+        multiworld.completion_condition[player] = lambda state: state.can_reach(fd, "Region", player)

--- a/worlds/jakanddaxter/Rules.py
+++ b/worlds/jakanddaxter/Rules.py
@@ -1,7 +1,7 @@
 import math
 import typing
 from BaseClasses import MultiWorld, CollectionState
-from .JakAndDaxterOptions import JakAndDaxterOptions
+from .JakAndDaxterOptions import JakAndDaxterOptions, EnableOrbsanity
 from .Items import orb_item_table
 from .locs import CellLocations as Cells
 from .Locations import location_table
@@ -16,7 +16,7 @@ def can_reach_orbs(state: CollectionState,
 
     # Global Orbsanity and No Orbsanity both treat orbs as completely interchangeable.
     # Per Level Orbsanity needs to know if you can reach orbs *in a particular level.*
-    if options.enable_orbsanity.value in [0, 2]:
+    if options.enable_orbsanity != EnableOrbsanity.option_per_level:
         return can_reach_orbs_global(state, player, multiworld)
     else:
         return can_reach_orbs_level(state, player, multiworld, level_name)
@@ -57,10 +57,10 @@ def can_trade(state: CollectionState,
               required_orbs: int,
               required_previous_trade: int = None) -> bool:
 
-    if options.enable_orbsanity.value == 1:
+    if options.enable_orbsanity == EnableOrbsanity.option_per_level:
         bundle_size = options.level_orbsanity_bundle_size.value
         return can_trade_orbsanity(state, player, bundle_size, required_orbs, required_previous_trade)
-    elif options.enable_orbsanity.value == 2:
+    elif options.enable_orbsanity == EnableOrbsanity.option_global:
         bundle_size = options.global_orbsanity_bundle_size.value
         return can_trade_orbsanity(state, player, bundle_size, required_orbs, required_previous_trade)
     else:

--- a/worlds/jakanddaxter/__init__.py
+++ b/worlds/jakanddaxter/__init__.py
@@ -4,7 +4,7 @@ import settings
 from Utils import local_path, visualize_regions
 from BaseClasses import Item, ItemClassification, Tutorial
 from .GameID import jak1_id, jak1_name, jak1_max
-from .JakAndDaxterOptions import JakAndDaxterOptions
+from .JakAndDaxterOptions import JakAndDaxterOptions, EnableOrbsanity
 from .Locations import JakAndDaxterLocation, location_table
 from .Items import JakAndDaxterItem, item_table
 from .locs import (CellLocations as Cells,
@@ -97,9 +97,9 @@ class JakAndDaxterWorld(World):
 
     # Helper function to get the correct orb bundle size.
     def get_orb_bundle_size(self) -> int:
-        if self.options.enable_orbsanity.value == 1:
+        if self.options.enable_orbsanity == EnableOrbsanity.option_per_level:
             return self.options.level_orbsanity_bundle_size.value
-        elif self.options.enable_orbsanity.value == 2:
+        elif self.options.enable_orbsanity == EnableOrbsanity.option_global:
             return self.options.global_orbsanity_bundle_size.value
         else:
             return 0
@@ -158,9 +158,9 @@ class JakAndDaxterWorld(World):
 
             # Handle Orbsanity option.
             # If it is OFF, don't add any orbs to the item pool.
-            # If it is ON, only add the orb bundle that matches the choice in options.
+            # If it is ON, don't add any orb bundles that don't match the chosen option.
             if (item_name in self.item_name_groups["Precursor Orbs"]
-                and ((self.options.enable_orbsanity.value == 0
+                and ((self.options.enable_orbsanity == EnableOrbsanity.option_off
                       or Orbs.to_game_id(item_id) != self.get_orb_bundle_size()))):
                 continue
 
@@ -181,4 +181,8 @@ class JakAndDaxterWorld(World):
         return self.options.as_dict("enable_move_randomizer",
                                     "enable_orbsanity",
                                     "global_orbsanity_bundle_size",
-                                    "level_orbsanity_bundle_size")
+                                    "level_orbsanity_bundle_size",
+                                    "fire_canyon_cell_count",
+                                    "mountain_pass_cell_count",
+                                    "lava_tube_cell_count",
+                                    "completion_condition")

--- a/worlds/jakanddaxter/__init__.py
+++ b/worlds/jakanddaxter/__init__.py
@@ -93,7 +93,7 @@ class JakAndDaxterWorld(World):
     # This will also set Locations, Location access rules, Region access rules, etc.
     def create_regions(self) -> None:
         create_regions(self.multiworld, self.options, self.player)
-        # visualize_regions(self.multiworld.get_region("Menu", self.player), "jak.puml")
+        visualize_regions(self.multiworld.get_region("Menu", self.player), "jakanddaxter.puml")
 
     # Helper function to get the correct orb bundle size.
     def get_orb_bundle_size(self) -> int:

--- a/worlds/jakanddaxter/client/MemoryReader.py
+++ b/worlds/jakanddaxter/client/MemoryReader.py
@@ -72,6 +72,19 @@ orbsanity_bundle_offset = offsets.define(sizeof_uint32)
 collected_bundle_level_offset = offsets.define(sizeof_uint8)
 collected_bundle_count_offset = offsets.define(sizeof_uint32)
 
+# Progression and Completion information.
+fire_canyon_cell_count_offset = offsets.define(sizeof_uint8)
+mountain_pass_cell_count_offset = offsets.define(sizeof_uint8)
+lava_tube_cell_count_offset = offsets.define(sizeof_uint8)
+completion_condition_offset = offsets.define(sizeof_uint8)
+completed_offset = offsets.define(sizeof_uint8)
+
+# Text to display in the HUD (32 char max per string).
+their_item_name_offset = offsets.define(sizeof_uint8, 32)
+their_item_owner_offset = offsets.define(sizeof_uint8, 32)
+my_item_name_offset = offsets.define(sizeof_uint8, 32)
+my_item_finder_offset = offsets.define(sizeof_uint8, 32)
+
 # The End.
 end_marker_offset = offsets.define(sizeof_uint8, 4)
 
@@ -244,19 +257,10 @@ class JakAndDaxterMemoryReader:
 
             for k in range(0, next_special_index):
                 next_special = self.read_goal_address(specials_checked_offset + (k * sizeof_uint32), sizeof_uint32)
-
-                # 112 is the game-task ID of `finalboss-movies`, which is written to this array when you grab
-                # the white eco. This is our victory condition, so we need to catch it and act on it.
-                if next_special == 112 and not self.finished_game:
-                    self.finished_game = True
-                    logger.info("Congratulations! You finished the game!")
-                else:
-
-                    # All other special checks handled as normal.
-                    special_ap_id = Specials.to_ap_id(next_special)
-                    if special_ap_id not in self.location_outbox:
-                        self.location_outbox.append(special_ap_id)
-                        logger.debug("Checked special: " + str(next_special))
+                special_ap_id = Specials.to_ap_id(next_special)
+                if special_ap_id not in self.location_outbox:
+                    self.location_outbox.append(special_ap_id)
+                    logger.debug("Checked special: " + str(next_special))
 
             died = self.read_goal_address(died_offset, sizeof_uint8)
             if died > 0:
@@ -301,6 +305,11 @@ class JakAndDaxterMemoryReader:
                         logger.debug("Checked orb bundle: " + str(bundle_ap_id))
 
                 # self.reset_orbsanity = True
+
+            completed = self.read_goal_address(completed_offset, sizeof_uint8)
+            if completed > 0 and not self.finished_game:
+                self.finished_game = True
+                logger.info("Congratulations! You finished the game!")
 
         except (ProcessError, MemoryReadError, WinAPIError):
             logger.error("The gk process has died. Restart the game and run \"/memr connect\" again.")

--- a/worlds/jakanddaxter/client/MemoryReader.py
+++ b/worlds/jakanddaxter/client/MemoryReader.py
@@ -185,6 +185,7 @@ class JakAndDaxterMemoryReader:
         # Checked Locations in game. Handle the entire outbox every tick until we're up to speed.
         if len(self.location_outbox) > self.outbox_index:
             location_callback(self.location_outbox)
+            self.save_data()
             self.outbox_index += 1
 
         if self.finished_game:

--- a/worlds/jakanddaxter/client/MemoryReader.py
+++ b/worlds/jakanddaxter/client/MemoryReader.py
@@ -17,6 +17,7 @@ from ..locs import (OrbLocations as Orbs,
 sizeof_uint64 = 8
 sizeof_uint32 = 4
 sizeof_uint8 = 1
+sizeof_float = 4
 
 
 # IMPORTANT: OpenGOAL memory structures are particular about the alignment, in memory, of member elements according to
@@ -73,10 +74,10 @@ collected_bundle_level_offset = offsets.define(sizeof_uint8)
 collected_bundle_count_offset = offsets.define(sizeof_uint32)
 
 # Progression and Completion information.
-fire_canyon_cell_count_offset = offsets.define(sizeof_uint8)
-mountain_pass_cell_count_offset = offsets.define(sizeof_uint8)
-lava_tube_cell_count_offset = offsets.define(sizeof_uint8)
-completion_condition_offset = offsets.define(sizeof_uint8)
+fire_canyon_unlock_offset = offsets.define(sizeof_float)
+mountain_pass_unlock_offset = offsets.define(sizeof_float)
+lava_tube_unlock_offset = offsets.define(sizeof_float)
+completion_goal_offset = offsets.define(sizeof_uint8)
 completed_offset = offsets.define(sizeof_uint8)
 
 # Text to display in the HUD (32 char max per string).
@@ -232,7 +233,7 @@ class JakAndDaxterMemoryReader:
         logger.info("Memory Reader Status:")
         logger.info("   Game process ID: " + (str(self.gk_process.process_id) if self.gk_process else "None"))
         logger.info("   Game state memory address: " + str(self.goal_address))
-        logger.info("   Last location checked: " + (str(self.location_outbox[self.outbox_index])
+        logger.info("   Last location checked: " + (str(self.location_outbox[self.outbox_index - 1])
                                                     if self.outbox_index else "None"))
 
     def read_memory(self) -> List[int]:

--- a/worlds/jakanddaxter/client/ReplClient.py
+++ b/worlds/jakanddaxter/client/ReplClient.py
@@ -330,6 +330,30 @@ class JakAndDaxterReplClient:
             logger.error(f"Unable to reset orb count for collected orbsanity bundle!")
         return ok
 
+    def setup_goals(self,
+                    fire_canyon_count: int,
+                    mountain_pass_count: int,
+                    lava_tube_count: int,
+                    completion_id: int) -> bool:
+        ok = self.send_form(f"(ap-setup-goals! "
+                            f"(the float {fire_canyon_count}) "
+                            f"(the float {mountain_pass_count})"
+                            f"(the float {lava_tube_count})"
+                            f"(the uint {completion_id})"
+                            f")")
+        if ok:
+            logger.debug(f"Set up goals: FC {fire_canyon_count}, "
+                         f"MP {mountain_pass_count}, "
+                         f"LT {lava_tube_count}, "
+                         f"GOAL {completion_id}!")
+        else:
+            logger.error(f"Unable to set up goals: FC {fire_canyon_count}, "
+                         f"MP {mountain_pass_count}, "
+                         f"LT {lava_tube_count}, "
+                         f"GOAL {completion_id}!")
+        return ok
+
+
     def save_data(self):
         with open("jakanddaxter_item_inbox.json", "w+") as f:
             dump = {

--- a/worlds/jakanddaxter/client/ReplClient.py
+++ b/worlds/jakanddaxter/client/ReplClient.py
@@ -68,6 +68,7 @@ class JakAndDaxterReplClient:
         # Receive Items from AP. Handle 1 item per tick.
         if len(self.item_inbox) > self.inbox_index:
             self.receive_item()
+            self.save_data()
             self.inbox_index += 1
 
         if self.received_deathlink:
@@ -373,7 +374,6 @@ class JakAndDaxterReplClient:
         else:
             logger.error(f"Unable to set up goals: FC {fc_count}, MP {mp_count}, LT {lt_count}, GOAL {goal_id}!")
         return ok
-
 
     def save_data(self):
         with open("jakanddaxter_item_inbox.json", "w+") as f:

--- a/worlds/jakanddaxter/docs/en_Jak and Daxter The Precursor Legacy.md
+++ b/worlds/jakanddaxter/docs/en_Jak and Daxter The Precursor Legacy.md
@@ -128,6 +128,30 @@ This will show you a list of all the moves in the game.
 - Yellow items indicate you possess that move, but you are missing its prerequisites.
 - Light blue items indicate you possess that move, as well as its prerequisites.
 
+## What does Orbsanity do?
+If you enable Orbsanity, Precursor Orbs will be turned into ordered lists of progressive checks. Every time you collect 
+a "bundle" of the correct number of orbs, you will trigger the next release in the list. Likewise, these bundles of orbs 
+will be added to the item pool to be randomized. There are several options to change the difficulty of this challenge. 
+
+- "Per Level" Orbsanity means the lists of orb checks are generated and populated for each level in the game.
+  - (Geyser Rock, Sandover Village, etc.)
+- "Global" Orbsanity means there is only one list of checks for the entire game.
+  - It does not matter where you pick up the orbs, they all count toward the same list.
+- The options with "Bundle Size" in the name indicate how many orbs are in a "bundle." This adds a number of Items 
+  and Locations to the pool inversely proportional to the size of the bundle.
+    - For example, if your bundle size is 20 orbs, you will add 100 items to the pool. If your bundle size is 250 orbs,
+      you will add 8 items to the pool.
+
+### A WARNING ABOUT ORBSANITY OPTIONS
+
+Unlike other settings, you CANNOT alter Orbsanity options after you generate a seed and start a game. **If you turn 
+Orbsanity OFF in the middle of an Orbsanity game, you will have NO way of completing the orb checks.** This may cause
+you to miss important progression items and prevent you (and others) from completing the run.
+
+When you connect your text client to the Archipelago Server, the server will tell the game what settings were chosen
+for this seed, and the game will apply those settings automatically. You can verify (but DO NOT ALTER) these settings 
+by navigating to `Options`, then `Archipelago Options`.
+
 ## I got soft-locked and can't leave, how do I get out of here?
 Open the game's menu, navigate to `Options`, then to `Archipelago Options`, then to `Warp To Home`. 
 Selecting this option will ask if you want to be teleported to Geyser Rock. From there, you can teleport back 

--- a/worlds/jakanddaxter/docs/setup_en.md
+++ b/worlds/jakanddaxter/docs/setup_en.md
@@ -73,15 +73,17 @@ At this time, this method of setup works on Windows only, but Linux support is a
     - You should see several messages appear after the compiler has run to 100% completion. If you see `The REPL is ready!` and `The Memory Reader is ready!` then that should indicate a successful startup.
     - The game should then load in the title screen.
 - You can *minimize* the 2 powershell windows, **BUT DO NOT CLOSE THEM.** They are required for Archipelago and the game to communicate with each other.
+- Use the text client to connect to the Archipelago server while on the title screen. This will communicate your current settings to the game.
 - Start a new game in the title screen, and play through the cutscenes.
-- Once you reach Geyser Rock, you can connect to the Archipelago server.
-  - Provide your slot/player name and hit Enter, and then start the game!
+- Once you reach Geyser Rock, you can start the game!
   - You can leave Geyser Rock immediately if you so choose - just step on the warp gate button.
 
 ***Returning / Async Game***
 
-- One important note is to connect to the Archipelago server **AFTER** you load your save file. This is to allow AP to give you all the items you had previously.
-- Otherwise, the same steps as New Game apply.
+- The same steps as New Game apply, with some exceptions: 
+  - Connect to the Archipelago server **BEFORE** you load your save file. This is to allow AP to give the game your current settings and all the items you had previously.
+  - **THESE SETTINGS AFFECT LOADING AND SAVING OF SAVE FILES, SO IT IS IMPORTANT TO DO THIS FIRST.**
+  - Then, instead of choosing `New Game` in the title menu, choose `Load Game`, then choose the save file **CORRESPONDING TO YOUR CURRENT ARCHIPELAGO CONNECTION.** 
 
 ## Troubleshooting
 

--- a/worlds/jakanddaxter/docs/setup_en.md
+++ b/worlds/jakanddaxter/docs/setup_en.md
@@ -121,3 +121,4 @@ Input file iso_data/jak1/MUS/TWEAKVAL.MUS does not exist.
 - The game needs to run in debug mode in order to allow the repl to connect to it. We hide the debug text on screen and play the game's introductory cutscenes properly.
 - The powershell windows cannot be run as background processes due to how the repl works, so the best we can do is minimize them.
 - The client is currently not very robust and doesn't handle failures gracefully. This may result in items not being delivered to the game, or location checks not being delivered to the server.
+- Orbsanity checks may show up out of order in the text client.

--- a/worlds/jakanddaxter/regs/BoggySwampRegions.py
+++ b/worlds/jakanddaxter/regs/BoggySwampRegions.py
@@ -1,7 +1,7 @@
 from typing import List
 from BaseClasses import CollectionState, MultiWorld
 from .RegionBase import JakAndDaxterRegion
-from .. import JakAndDaxterOptions
+from .. import JakAndDaxterOptions, EnableOrbsanity
 from ..Rules import can_fight, can_reach_orbs
 
 
@@ -155,7 +155,7 @@ def build_regions(level_name: str, multiworld: MultiWorld, options: JakAndDaxter
 
     # If Per-Level Orbsanity is enabled, build the special Orbsanity Region. This is a virtual region always
     # accessible to Main Area. The Locations within are automatically checked when you collect enough orbs.
-    if options.enable_orbsanity.value == 1:
+    if options.enable_orbsanity == EnableOrbsanity.option_per_level:
         orbs = JakAndDaxterRegion("Orbsanity", player, multiworld, level_name)
 
         bundle_size = options.level_orbsanity_bundle_size.value

--- a/worlds/jakanddaxter/regs/FireCanyonRegions.py
+++ b/worlds/jakanddaxter/regs/FireCanyonRegions.py
@@ -1,7 +1,7 @@
 from typing import List
 from BaseClasses import CollectionState, MultiWorld
 from .RegionBase import JakAndDaxterRegion
-from .. import JakAndDaxterOptions
+from .. import JakAndDaxterOptions, EnableOrbsanity
 from ..Rules import can_reach_orbs
 from ..locs import CellLocations as Cells, ScoutLocations as Scouts
 
@@ -18,7 +18,7 @@ def build_regions(level_name: str, multiworld: MultiWorld, options: JakAndDaxter
 
     # If Per-Level Orbsanity is enabled, build the special Orbsanity Region. This is a virtual region always
     # accessible to Main Area. The Locations within are automatically checked when you collect enough orbs.
-    if options.enable_orbsanity.value == 1:
+    if options.enable_orbsanity == EnableOrbsanity.option_per_level:
         orbs = JakAndDaxterRegion("Orbsanity", player, multiworld, level_name)
 
         bundle_size = options.level_orbsanity_bundle_size.value

--- a/worlds/jakanddaxter/regs/ForbiddenJungleRegions.py
+++ b/worlds/jakanddaxter/regs/ForbiddenJungleRegions.py
@@ -1,7 +1,7 @@
 from typing import List
 from BaseClasses import CollectionState, MultiWorld
 from .RegionBase import JakAndDaxterRegion
-from .. import JakAndDaxterOptions
+from .. import JakAndDaxterOptions, EnableOrbsanity
 from ..Rules import can_free_scout_flies, can_fight, can_reach_orbs
 
 
@@ -83,7 +83,7 @@ def build_regions(level_name: str, multiworld: MultiWorld, options: JakAndDaxter
 
     # If Per-Level Orbsanity is enabled, build the special Orbsanity Region. This is a virtual region always
     # accessible to Main Area. The Locations within are automatically checked when you collect enough orbs.
-    if options.enable_orbsanity.value == 1:
+    if options.enable_orbsanity == EnableOrbsanity.option_per_level:
         orbs = JakAndDaxterRegion("Orbsanity", player, multiworld, level_name)
 
         bundle_size = options.level_orbsanity_bundle_size.value
@@ -98,4 +98,4 @@ def build_regions(level_name: str, multiworld: MultiWorld, options: JakAndDaxter
         multiworld.regions.append(orbs)
         main_area.connect(orbs)
 
-    return [main_area]
+    return [main_area, temple_int_post_blue]

--- a/worlds/jakanddaxter/regs/GeyserRockRegions.py
+++ b/worlds/jakanddaxter/regs/GeyserRockRegions.py
@@ -1,7 +1,7 @@
 from typing import List
 from BaseClasses import CollectionState, MultiWorld
 from .RegionBase import JakAndDaxterRegion
-from .. import JakAndDaxterOptions
+from .. import JakAndDaxterOptions, EnableOrbsanity
 from ..Rules import can_reach_orbs
 from ..locs import ScoutLocations as Scouts
 
@@ -27,7 +27,7 @@ def build_regions(level_name: str, multiworld: MultiWorld, options: JakAndDaxter
 
     # If Per-Level Orbsanity is enabled, build the special Orbsanity Region. This is a virtual region always
     # accessible to Main Area. The Locations within are automatically checked when you collect enough orbs.
-    if options.enable_orbsanity.value == 1:
+    if options.enable_orbsanity == EnableOrbsanity.option_per_level:
         orbs = JakAndDaxterRegion("Orbsanity", player, multiworld, level_name)
 
         bundle_size = options.level_orbsanity_bundle_size.value

--- a/worlds/jakanddaxter/regs/GolAndMaiasCitadelRegions.py
+++ b/worlds/jakanddaxter/regs/GolAndMaiasCitadelRegions.py
@@ -1,7 +1,7 @@
 from typing import List
 from BaseClasses import CollectionState, MultiWorld
 from .RegionBase import JakAndDaxterRegion
-from .. import JakAndDaxterOptions
+from .. import JakAndDaxterOptions, EnableOrbsanity
 from ..Rules import can_free_scout_flies, can_fight, can_reach_orbs
 
 
@@ -58,6 +58,8 @@ def build_regions(level_name: str, multiworld: MultiWorld, options: JakAndDaxter
 
     final_boss = JakAndDaxterRegion("Final Boss", player, multiworld, level_name, 0)
 
+    final_door = JakAndDaxterRegion("Final Door", player, multiworld, level_name, 0)
+
     # Jump Dive required for a lot of buttons, prepare yourself.
     main_area.connect(robot_scaffolding, rule=lambda state:
                       state.has("Jump Dive", player)
@@ -105,6 +107,9 @@ def build_regions(level_name: str, multiworld: MultiWorld, options: JakAndDaxter
 
     final_boss.connect(rotating_tower)  # Take elevator back down.
 
+    # Final door. Need 100 power cells.
+    final_boss.connect(final_door, rule=lambda state: state.has("Power Cell", player, 100))
+
     multiworld.regions.append(main_area)
     multiworld.regions.append(robot_scaffolding)
     multiworld.regions.append(jump_pad_room)
@@ -115,7 +120,7 @@ def build_regions(level_name: str, multiworld: MultiWorld, options: JakAndDaxter
 
     # If Per-Level Orbsanity is enabled, build the special Orbsanity Region. This is a virtual region always
     # accessible to Main Area. The Locations within are automatically checked when you collect enough orbs.
-    if options.enable_orbsanity.value == 1:
+    if options.enable_orbsanity == EnableOrbsanity.option_per_level:
         orbs = JakAndDaxterRegion("Orbsanity", player, multiworld, level_name)
 
         bundle_size = options.level_orbsanity_bundle_size.value
@@ -130,4 +135,4 @@ def build_regions(level_name: str, multiworld: MultiWorld, options: JakAndDaxter
         multiworld.regions.append(orbs)
         main_area.connect(orbs)
 
-    return [main_area, final_boss]
+    return [main_area, final_boss, final_door]

--- a/worlds/jakanddaxter/regs/GolAndMaiasCitadelRegions.py
+++ b/worlds/jakanddaxter/regs/GolAndMaiasCitadelRegions.py
@@ -117,6 +117,7 @@ def build_regions(level_name: str, multiworld: MultiWorld, options: JakAndDaxter
     multiworld.regions.append(bunny_room)
     multiworld.regions.append(rotating_tower)
     multiworld.regions.append(final_boss)
+    multiworld.regions.append(final_door)
 
     # If Per-Level Orbsanity is enabled, build the special Orbsanity Region. This is a virtual region always
     # accessible to Main Area. The Locations within are automatically checked when you collect enough orbs.

--- a/worlds/jakanddaxter/regs/LavaTubeRegions.py
+++ b/worlds/jakanddaxter/regs/LavaTubeRegions.py
@@ -1,7 +1,7 @@
 from typing import List
 from BaseClasses import CollectionState, MultiWorld
 from .RegionBase import JakAndDaxterRegion
-from .. import JakAndDaxterOptions
+from .. import JakAndDaxterOptions, EnableOrbsanity
 from ..Rules import can_reach_orbs
 from ..locs import CellLocations as Cells, ScoutLocations as Scouts
 
@@ -18,7 +18,7 @@ def build_regions(level_name: str, multiworld: MultiWorld, options: JakAndDaxter
 
     # If Per-Level Orbsanity is enabled, build the special Orbsanity Region. This is a virtual region always
     # accessible to Main Area. The Locations within are automatically checked when you collect enough orbs.
-    if options.enable_orbsanity.value == 1:
+    if options.enable_orbsanity == EnableOrbsanity.option_per_level:
         orbs = JakAndDaxterRegion("Orbsanity", player, multiworld, level_name)
 
         bundle_size = options.level_orbsanity_bundle_size.value

--- a/worlds/jakanddaxter/regs/LostPrecursorCityRegions.py
+++ b/worlds/jakanddaxter/regs/LostPrecursorCityRegions.py
@@ -1,7 +1,7 @@
 from typing import List
 from BaseClasses import CollectionState, MultiWorld
 from .RegionBase import JakAndDaxterRegion
-from .. import JakAndDaxterOptions
+from .. import JakAndDaxterOptions, EnableOrbsanity
 from ..Rules import can_free_scout_flies, can_fight, can_reach_orbs
 
 
@@ -130,7 +130,7 @@ def build_regions(level_name: str, multiworld: MultiWorld, options: JakAndDaxter
 
     # If Per-Level Orbsanity is enabled, build the special Orbsanity Region. This is a virtual region always
     # accessible to Main Area. The Locations within are automatically checked when you collect enough orbs.
-    if options.enable_orbsanity.value == 1:
+    if options.enable_orbsanity == EnableOrbsanity.option_per_level:
         orbs = JakAndDaxterRegion("Orbsanity", player, multiworld, level_name)
 
         bundle_size = options.level_orbsanity_bundle_size.value

--- a/worlds/jakanddaxter/regs/LostPrecursorCityRegions.py
+++ b/worlds/jakanddaxter/regs/LostPrecursorCityRegions.py
@@ -57,7 +57,12 @@ def build_regions(level_name: str, multiworld: MultiWorld, options: JakAndDaxter
     capsule_room = JakAndDaxterRegion("Capsule Chamber", player, multiworld, level_name, 6)
 
     # Use jump dive to activate button inside the capsule. Blue eco vent can ready the chamber and get the scout fly.
-    capsule_room.add_cell_locations([47], access_rule=lambda state: state.has("Jump Dive", player))
+    capsule_room.add_cell_locations([47], access_rule=lambda state:
+                                    state.has("Jump Dive", player)
+                                    and (state.has("Double Jump", player)
+                                         or state.has("Jump Kick", player)
+                                         or (state.has("Punch", player)
+                                             and state.has("Punch Uppercut", player))))
     capsule_room.add_fly_locations([327729])
 
     second_slide = JakAndDaxterRegion("Second Slide", player, multiworld, level_name, 31)

--- a/worlds/jakanddaxter/regs/MistyIslandRegions.py
+++ b/worlds/jakanddaxter/regs/MistyIslandRegions.py
@@ -1,7 +1,7 @@
 from typing import List
 from BaseClasses import CollectionState, MultiWorld
 from .RegionBase import JakAndDaxterRegion
-from .. import JakAndDaxterOptions
+from .. import JakAndDaxterOptions, EnableOrbsanity
 from ..Rules import can_free_scout_flies, can_fight, can_reach_orbs
 
 
@@ -116,7 +116,7 @@ def build_regions(level_name: str, multiworld: MultiWorld, options: JakAndDaxter
 
     # If Per-Level Orbsanity is enabled, build the special Orbsanity Region. This is a virtual region always
     # accessible to Main Area. The Locations within are automatically checked when you collect enough orbs.
-    if options.enable_orbsanity.value == 1:
+    if options.enable_orbsanity == EnableOrbsanity.option_per_level:
         orbs = JakAndDaxterRegion("Orbsanity", player, multiworld, level_name)
 
         bundle_size = options.level_orbsanity_bundle_size.value

--- a/worlds/jakanddaxter/regs/MountainPassRegions.py
+++ b/worlds/jakanddaxter/regs/MountainPassRegions.py
@@ -1,7 +1,7 @@
 from typing import List
 from BaseClasses import CollectionState, MultiWorld
 from .RegionBase import JakAndDaxterRegion
-from .. import JakAndDaxterOptions
+from .. import JakAndDaxterOptions, EnableOrbsanity
 from ..Rules import can_reach_orbs
 from ..locs import ScoutLocations as Scouts
 
@@ -34,7 +34,7 @@ def build_regions(level_name: str, multiworld: MultiWorld, options: JakAndDaxter
 
     # If Per-Level Orbsanity is enabled, build the special Orbsanity Region. This is a virtual region always
     # accessible to Main Area. The Locations within are automatically checked when you collect enough orbs.
-    if options.enable_orbsanity.value == 1:
+    if options.enable_orbsanity == EnableOrbsanity.option_per_level:
         orbs = JakAndDaxterRegion("Orbsanity", player, multiworld, level_name)
 
         bundle_size = options.level_orbsanity_bundle_size.value

--- a/worlds/jakanddaxter/regs/PrecursorBasinRegions.py
+++ b/worlds/jakanddaxter/regs/PrecursorBasinRegions.py
@@ -1,7 +1,7 @@
 from typing import List
 from BaseClasses import CollectionState, MultiWorld
 from .RegionBase import JakAndDaxterRegion
-from .. import JakAndDaxterOptions
+from .. import JakAndDaxterOptions, EnableOrbsanity
 from ..Rules import can_reach_orbs
 from ..locs import CellLocations as Cells, ScoutLocations as Scouts
 
@@ -18,7 +18,7 @@ def build_regions(level_name: str, multiworld: MultiWorld, options: JakAndDaxter
 
     # If Per-Level Orbsanity is enabled, build the special Orbsanity Region. This is a virtual region always
     # accessible to Main Area. The Locations within are automatically checked when you collect enough orbs.
-    if options.enable_orbsanity.value == 1:
+    if options.enable_orbsanity == EnableOrbsanity.option_per_level:
         orbs = JakAndDaxterRegion("Orbsanity", player, multiworld, level_name)
 
         bundle_size = options.level_orbsanity_bundle_size.value

--- a/worlds/jakanddaxter/regs/RockVillageRegions.py
+++ b/worlds/jakanddaxter/regs/RockVillageRegions.py
@@ -1,7 +1,7 @@
 from typing import List
 from BaseClasses import CollectionState, MultiWorld
 from .RegionBase import JakAndDaxterRegion
-from .. import JakAndDaxterOptions
+from .. import JakAndDaxterOptions, EnableOrbsanity
 from ..Rules import can_free_scout_flies, can_trade, can_reach_orbs
 
 
@@ -63,7 +63,7 @@ def build_regions(level_name: str, multiworld: MultiWorld, options: JakAndDaxter
 
     # If Per-Level Orbsanity is enabled, build the special Orbsanity Region. This is a virtual region always
     # accessible to Main Area. The Locations within are automatically checked when you collect enough orbs.
-    if options.enable_orbsanity.value == 1:
+    if options.enable_orbsanity == EnableOrbsanity.option_per_level:
         orbs = JakAndDaxterRegion("Orbsanity", player, multiworld, level_name)
 
         bundle_size = options.level_orbsanity_bundle_size.value

--- a/worlds/jakanddaxter/regs/SandoverVillageRegions.py
+++ b/worlds/jakanddaxter/regs/SandoverVillageRegions.py
@@ -1,7 +1,7 @@
 from typing import List
 from BaseClasses import CollectionState, MultiWorld
 from .RegionBase import JakAndDaxterRegion
-from .. import JakAndDaxterOptions
+from .. import JakAndDaxterOptions, EnableOrbsanity
 from ..Rules import can_free_scout_flies, can_trade, can_reach_orbs
 
 
@@ -71,7 +71,7 @@ def build_regions(level_name: str, multiworld: MultiWorld, options: JakAndDaxter
 
     # If Per-Level Orbsanity is enabled, build the special Orbsanity Region. This is a virtual region always
     # accessible to Main Area. The Locations within are automatically checked when you collect enough orbs.
-    if options.enable_orbsanity.value == 1:
+    if options.enable_orbsanity == EnableOrbsanity.option_per_level:
         orbs = JakAndDaxterRegion("Orbsanity", player, multiworld, level_name)
 
         bundle_size = options.level_orbsanity_bundle_size.value

--- a/worlds/jakanddaxter/regs/SentinelBeachRegions.py
+++ b/worlds/jakanddaxter/regs/SentinelBeachRegions.py
@@ -1,7 +1,7 @@
 from typing import List
 from BaseClasses import CollectionState, MultiWorld
 from .RegionBase import JakAndDaxterRegion
-from .. import JakAndDaxterOptions
+from .. import JakAndDaxterOptions, EnableOrbsanity
 from ..Rules import can_free_scout_flies, can_fight, can_reach_orbs
 
 
@@ -85,7 +85,7 @@ def build_regions(level_name: str, multiworld: MultiWorld, options: JakAndDaxter
 
     # If Per-Level Orbsanity is enabled, build the special Orbsanity Region. This is a virtual region always
     # accessible to Main Area. The Locations within are automatically checked when you collect enough orbs.
-    if options.enable_orbsanity.value == 1:
+    if options.enable_orbsanity == EnableOrbsanity.option_per_level:
         orbs = JakAndDaxterRegion("Orbsanity", player, multiworld, level_name)
 
         bundle_size = options.level_orbsanity_bundle_size.value

--- a/worlds/jakanddaxter/regs/SnowyMountainRegions.py
+++ b/worlds/jakanddaxter/regs/SnowyMountainRegions.py
@@ -1,7 +1,7 @@
 from typing import List
 from BaseClasses import CollectionState, MultiWorld
 from .RegionBase import JakAndDaxterRegion
-from .. import JakAndDaxterOptions
+from .. import JakAndDaxterOptions, EnableOrbsanity
 from ..Rules import can_free_scout_flies, can_fight, can_reach_orbs
 
 
@@ -192,7 +192,7 @@ def build_regions(level_name: str, multiworld: MultiWorld, options: JakAndDaxter
 
     # If Per-Level Orbsanity is enabled, build the special Orbsanity Region. This is a virtual region always
     # accessible to Main Area. The Locations within are automatically checked when you collect enough orbs.
-    if options.enable_orbsanity.value == 1:
+    if options.enable_orbsanity == EnableOrbsanity.option_per_level:
         orbs = JakAndDaxterRegion("Orbsanity", player, multiworld, level_name)
 
         bundle_size = options.level_orbsanity_bundle_size.value

--- a/worlds/jakanddaxter/regs/SpiderCaveRegions.py
+++ b/worlds/jakanddaxter/regs/SpiderCaveRegions.py
@@ -1,7 +1,7 @@
 from typing import List
 from BaseClasses import CollectionState, MultiWorld
 from .RegionBase import JakAndDaxterRegion
-from .. import JakAndDaxterOptions
+from .. import JakAndDaxterOptions, EnableOrbsanity
 from ..Rules import can_free_scout_flies, can_fight, can_reach_orbs
 
 
@@ -110,7 +110,7 @@ def build_regions(level_name: str, multiworld: MultiWorld, options: JakAndDaxter
 
     # If Per-Level Orbsanity is enabled, build the special Orbsanity Region. This is a virtual region always
     # accessible to Main Area. The Locations within are automatically checked when you collect enough orbs.
-    if options.enable_orbsanity.value == 1:
+    if options.enable_orbsanity == EnableOrbsanity.option_per_level:
         orbs = JakAndDaxterRegion("Orbsanity", player, multiworld, level_name)
 
         bundle_size = options.level_orbsanity_bundle_size.value

--- a/worlds/jakanddaxter/regs/VolcanicCraterRegions.py
+++ b/worlds/jakanddaxter/regs/VolcanicCraterRegions.py
@@ -1,7 +1,7 @@
 from typing import List
 from BaseClasses import CollectionState, MultiWorld
 from .RegionBase import JakAndDaxterRegion
-from .. import JakAndDaxterOptions
+from .. import JakAndDaxterOptions, EnableOrbsanity
 from ..Rules import can_free_scout_flies, can_trade, can_reach_orbs
 from ..locs import CellLocations as Cells, ScoutLocations as Scouts
 
@@ -38,7 +38,7 @@ def build_regions(level_name: str, multiworld: MultiWorld, options: JakAndDaxter
 
     # If Per-Level Orbsanity is enabled, build the special Orbsanity Region. This is a virtual region always
     # accessible to Main Area. The Locations within are automatically checked when you collect enough orbs.
-    if options.enable_orbsanity.value == 1:
+    if options.enable_orbsanity == EnableOrbsanity.option_per_level:
         orbs = JakAndDaxterRegion("Orbsanity", player, multiworld, level_name)
 
         bundle_size = options.level_orbsanity_bundle_size.value


### PR DESCRIPTION
## What is this fixing or adding?
- Fixes https://github.com/ArchipelaGOAL/Archipelago/issues/35 by increasing the minimum height of the orb cache top when it opens, so Jak can walk under it.
- Fixes part of https://github.com/ArchipelaGOAL/Archipelago/issues/34, where the Raise The Chamber power cell needed more height than a single jump (may need to take the chamber back down to get it).
- Fixes https://github.com/ArchipelaGOAL/Archipelago/issues/33.
- Implements https://github.com/ArchipelaGOAL/Archipelago/issues/27.
- Implements https://github.com/ArchipelaGOAL/Archipelago/issues/22 by adding the following completion options:
  - Defeat the Dark Eco Plant
  - Defeat Klaww
  - Defeat Gol and Maia
  - Cross Fire Canyon
  - Cross Mountain Pass
  - Cross Lava Tube
  - Open the 100 Cell Door
- Added options to change the power cell requirements for Fire Canyon, Mountain Pass, and Lava Tube.
- Implements https://github.com/ArchipelaGOAL/Archipelago/issues/20, by changing the order of loading a save and connecting to AP. **You connect on the title screen, then load the correct save.**
- Implements https://github.com/ArchipelaGOAL/Archipelago/issues/19. You can see `Got {Item} From {Player}` in the normal HUD, and `Sent {Item} To {Player}` in the alternate HUD. Both HUD modes change to `Found {Item}` when you find your own item.
- Fixed an issue where dying in front of the final elevator will improperly cause it to spawn.

## How was this tested?
- Individual unit tests of each fix or feature, combined with an end-to-end test of a 100-cell-door run, with orbsanity, with move randomizer, and with altered cell counts for connector levels.

## If this makes graphical changes, please attach screenshots.
- See issue links above for screenshots.