### PR TITLE
Rename completion_condition to jak_completion_condition

### DIFF
--- a/worlds/jakanddaxter/Client.py
+++ b/worlds/jakanddaxter/Client.py
@@ -119,12 +119,18 @@ class JakAndDaxterContext(CommonContext):
             else:
                 orbsanity_bundle = 1
 
+            # Keep compatibility with 0.0.8 at least for now
+            if "completion_condition" in slot_data:
+                goal_id = slot_data["completion_condition"]
+            else:
+                goal_id = slot_data["jak_completion_condition"]
+
             self.repl.setup_options(orbsanity_option,
                                     orbsanity_bundle,
                                     slot_data["fire_canyon_cell_count"],
                                     slot_data["mountain_pass_cell_count"],
                                     slot_data["lava_tube_cell_count"],
-                                    slot_data["completion_condition"])
+                                    goal_id)
 
             # Because Orbsanity and the orb traders in the game are intrinsically linked, we need the server
             # to track our trades at all times to support async play. "Retrieved" will tell us the orbs we lost,

--- a/worlds/jakanddaxter/JakAndDaxterOptions.py
+++ b/worlds/jakanddaxter/JakAndDaxterOptions.py
@@ -112,4 +112,4 @@ class JakAndDaxterOptions(PerGameCommonOptions):
     fire_canyon_cell_count: FireCanyonCellCount
     mountain_pass_cell_count: MountainPassCellCount
     lava_tube_cell_count: LavaTubeCellCount
-    completion_condition: CompletionCondition
+    jak_completion_condition: CompletionCondition

--- a/worlds/jakanddaxter/Regions.py
+++ b/worlds/jakanddaxter/Regions.py
@@ -108,25 +108,25 @@ def create_regions(multiworld: MultiWorld, options: JakAndDaxterOptions, player:
     lt.connect(gmc)  # gmc->fb connection defined internally by GolAndMaiasCitadelRegions.
 
     # Set the completion condition.
-    if options.completion_condition == CompletionCondition.option_cross_fire_canyon:
+    if options.jak_completion_condition == CompletionCondition.option_cross_fire_canyon:
         multiworld.completion_condition[player] = lambda state: state.can_reach(rv, "Region", player)
 
-    elif options.completion_condition == CompletionCondition.option_cross_mountain_pass:
+    elif options.jak_completion_condition == CompletionCondition.option_cross_mountain_pass:
         multiworld.completion_condition[player] = lambda state: state.can_reach(vc, "Region", player)
 
-    elif options.completion_condition == CompletionCondition.option_cross_lava_tube:
+    elif options.jak_completion_condition == CompletionCondition.option_cross_lava_tube:
         multiworld.completion_condition[player] = lambda state: state.can_reach(gmc, "Region", player)
 
-    elif options.completion_condition == CompletionCondition.option_defeat_dark_eco_plant:
+    elif options.jak_completion_condition == CompletionCondition.option_defeat_dark_eco_plant:
         multiworld.completion_condition[player] = lambda state: state.can_reach(fjp, "Region", player)
 
-    elif options.completion_condition == CompletionCondition.option_defeat_klaww:
+    elif options.jak_completion_condition == CompletionCondition.option_defeat_klaww:
         multiworld.completion_condition[player] = lambda state: state.can_reach(mp, "Region", player)
 
-    elif options.completion_condition == CompletionCondition.option_defeat_gol_and_maia:
+    elif options.jak_completion_condition == CompletionCondition.option_defeat_gol_and_maia:
         multiworld.completion_condition[player] = lambda state: state.can_reach(fb, "Region", player)
 
-    elif options.completion_condition == CompletionCondition.option_open_100_cell_door:
+    elif options.jak_completion_condition == CompletionCondition.option_open_100_cell_door:
         multiworld.completion_condition[player] = lambda state: state.can_reach(fd, "Region", player)
 
     # As a final sanity check on these options, verify that we have enough locations to allow us to cross

--- a/worlds/jakanddaxter/__init__.py
+++ b/worlds/jakanddaxter/__init__.py
@@ -185,4 +185,4 @@ class JakAndDaxterWorld(World):
                                     "fire_canyon_cell_count",
                                     "mountain_pass_cell_count",
                                     "lava_tube_cell_count",
-                                    "completion_condition")
+                                    "jak_completion_condition")


### PR DESCRIPTION
## What is this fixing or adding?
The old option system seems to play some havoc with an option named completion condition. This PR aims to rename that and 

## How was this tested?
Using a test gen with the problematic yaml in discord, as well as logging into a 0.0.8 orbsanity file.
