### PR TITLE
Temper and Harden Text Client

### DIFF
--- a/worlds/jakanddaxter/Client.py
+++ b/worlds/jakanddaxter/Client.py
@@ -51,7 +51,7 @@ class JakAndDaxterClientCommandProcessor(ClientCommandProcessor):
         - status : check internal status of the REPL."""
         if arguments:
             if arguments[0] == "connect":
-                logger.info("This may take a bit... Wait for the success audio cue before continuing!")
+                self.ctx.on_log_info("This may take a bit... Wait for the success audio cue before continuing!")
                 self.ctx.repl.initiated_connect = True
             if arguments[0] == "status":
                 create_task_log_exception(self.ctx.repl.print_status())
@@ -64,7 +64,7 @@ class JakAndDaxterClientCommandProcessor(ClientCommandProcessor):
             if arguments[0] == "connect":
                 self.ctx.memr.initiated_connect = True
             if arguments[0] == "status":
-                self.ctx.memr.print_status()
+                create_task_log_exception(self.ctx.memr.print_status())
 
 
 class JakAndDaxterContext(CommonContext):
@@ -85,8 +85,14 @@ class JakAndDaxterContext(CommonContext):
     memr_task: asyncio.Task
 
     def __init__(self, server_address: Optional[str], password: Optional[str]) -> None:
-        self.repl = JakAndDaxterReplClient()
-        self.memr = JakAndDaxterMemoryReader()
+        self.repl = JakAndDaxterReplClient(self.on_log_error,
+                                           self.on_log_warn,
+                                           self.on_log_success,
+                                           self.on_log_info)
+        self.memr = JakAndDaxterMemoryReader(self.on_log_error,
+                                             self.on_log_warn,
+                                             self.on_log_success,
+                                             self.on_log_info)
         # self.repl.load_data()
         # self.memr.load_data()
         super().__init__(server_address, password)
@@ -219,7 +225,7 @@ class JakAndDaxterContext(CommonContext):
             player = self.player_names[self.slot] if self.slot is not None else "Jak"
             death_text = self.memr.cause_of_death.replace("Jak", player)
             await self.send_death(death_text)
-            logger.info(death_text)
+            self.on_log_warn(death_text)
 
         # Reset all flags, but leave the death count alone.
         self.memr.send_deathlink = False
@@ -246,6 +252,29 @@ class JakAndDaxterContext(CommonContext):
     def on_orb_trade(self, orbs_changed: int):
         create_task_log_exception(self.ap_inform_orb_trade(orbs_changed))
 
+    def on_log_error(self, message: str):
+        if self.ui:
+            color = self.jsontotextparser.color_codes["red"]
+            self.ui.log_panels["Archipelago"].on_message_markup(f"[color={color}]{message}[/color]")
+            self.ui.log_panels["All"].on_message_markup(f"[color={color}]{message}[/color]")
+
+    def on_log_warn(self, message: str):
+        if self.ui:
+            color = self.jsontotextparser.color_codes["orange"]
+            self.ui.log_panels["Archipelago"].on_message_markup(f"[color={color}]{message}[/color]")
+            self.ui.log_panels["All"].on_message_markup(f"[color={color}]{message}[/color]")
+
+    def on_log_success(self, message: str):
+        if self.ui:
+            color = self.jsontotextparser.color_codes["green"]
+            self.ui.log_panels["Archipelago"].on_message_markup(f"[color={color}]{message}[/color]")
+            self.ui.log_panels["All"].on_message_markup(f"[color={color}]{message}[/color]")
+
+    def on_log_info(self, message: str):
+        if self.ui:
+            self.ui.log_panels["Archipelago"].on_message_markup(f"{message}")
+            self.ui.log_panels["All"].on_message_markup(f"{message}")
+
     async def run_repl_loop(self):
         while True:
             await self.repl.main_tick()
@@ -270,14 +299,14 @@ async def run_game(ctx: JakAndDaxterContext):
         pymem.Pymem("gk.exe")  # The GOAL Kernel
         gk_running = True
     except ProcessNotFound:
-        logger.info("Game not running, attempting to start.")
+        ctx.on_log_warn("Game not running, attempting to start.")
 
     goalc_running = False
     try:
         pymem.Pymem("goalc.exe")  # The GOAL Compiler and REPL
         goalc_running = True
     except ProcessNotFound:
-        logger.info("Compiler not running, attempting to start.")
+        ctx.on_log_warn("Compiler not running, attempting to start.")
 
     try:
         # Validate folder and file structures of the ArchipelaGOAL root directory.
@@ -285,23 +314,26 @@ async def run_game(ctx: JakAndDaxterContext):
 
         # Always trust your instincts.
         if "/" not in root_path:
-            logger.error(f"The ArchipelaGOAL root directory contains no path. (Are you missing forward slashes?) "
-                         f"Please check the value of `jakanddaxter_options > root_directory` in your host.yaml file.")
+            msg = (f"The ArchipelaGOAL root directory contains no path. (Are you missing forward slashes?)\n"
+                   f"Please check the value of `jakanddaxter_options > root_directory` in your host.yaml file.")
+            ctx.on_log_error(msg)
             return
 
         # Start by checking the existence of the root directory provided in the host.yaml file.
         root_path = os.path.normpath(root_path)
         if not os.path.exists(root_path):
-            logger.error(f"The ArchipelaGOAL root directory does not exist, unable to locate game executables. "
-                         f"Please check the value of `jakanddaxter_options > root_directory` in your host.yaml file.")
+            msg = (f"The ArchipelaGOAL root directory does not exist, unable to locate game executables.\n"
+                   f"Please check the value of `jakanddaxter_options > root_directory` in your host.yaml file.")
+            ctx.on_log_error(msg)
             return
 
         # Now double-check the existence of the two executables we need.
         gk_path = os.path.join(root_path, "gk.exe")
         goalc_path = os.path.join(root_path, "goalc.exe")
         if not os.path.exists(gk_path) or not os.path.exists(goalc_path):
-            logger.error(f"The Game and Compiler executables could not be found in the ArchipelaGOAL root directory. "
-                         f"Please check the OpenGOAL Launcher to verify installation of the ArchipelaGOAL mod.")
+            msg = (f"The Game and Compiler executables could not be found in the ArchipelaGOAL root directory.\n"
+                   f"Please check the OpenGOAL Launcher to verify installation of the ArchipelaGOAL mod.")
+            ctx.on_log_error(msg)
             return
 
         # IMPORTANT: Before we check the existence of the next piece, we must ask "Are you a developer?"
@@ -319,9 +351,10 @@ async def run_game(ctx: JakAndDaxterContext):
             #  we may be able to remove this step.
             iso_data_path = os.path.join(root_path, "data", "iso_data")
             if not os.path.exists(iso_data_path):
-                logger.error(f"The iso_data folder could not be found, unable to compile game. "
-                             f"Please copy the iso_data folder from its original location to the mod's data folder. "
-                             f"(See setup guide for more details.)")
+                msg = (f"The iso_data folder could not be found, unable to compile game.\n"
+                       f"Please copy the iso_data folder from its original location to the mod's data folder.\n"
+                       f"(See setup guide for more details.)")
+                ctx.on_log_error(msg)
                 return
 
         # Now we can FINALLY attempt to start the programs.
@@ -351,12 +384,12 @@ async def run_game(ctx: JakAndDaxterContext):
                 creationflags=subprocess.CREATE_NEW_CONSOLE)  # These need to be new consoles for stability.
 
     except AttributeError as e:
-        logger.error(f"Host.yaml does not contain {e.args[0]}, unable to locate game executables.")
+        ctx.on_log_error(f"Host.yaml does not contain {e.args[0]}, unable to locate game executables.")
         return
 
     # Auto connect the repl and memr agents. Sleep 5 because goalc takes just a little bit of time to load,
     # and it's not something we can await.
-    logger.info("This may take a bit... Wait for the game's title sequence before continuing!")
+    ctx.on_log_info("This may take a bit... Wait for the game's title sequence before continuing!")
     await asyncio.sleep(5)
     ctx.repl.initiated_connect = True
     ctx.memr.initiated_connect = True

--- a/worlds/jakanddaxter/Client.py
+++ b/worlds/jakanddaxter/Client.py
@@ -93,7 +93,12 @@ class JakAndDaxterContext(CommonContext):
                                            self.on_log_warn,
                                            self.on_log_success,
                                            self.on_log_info)
-        self.memr = JakAndDaxterMemoryReader(self.on_log_error,
+        self.memr = JakAndDaxterMemoryReader(self.on_location_check,
+                                             self.on_finish_check,
+                                             self.on_deathlink_check,
+                                             self.on_deathlink_toggle,
+                                             self.on_orb_trade,
+                                             self.on_log_error,
                                              self.on_log_warn,
                                              self.on_log_success,
                                              self.on_log_info)
@@ -290,11 +295,7 @@ class JakAndDaxterContext(CommonContext):
 
     async def run_memr_loop(self):
         while True:
-            await self.memr.main_tick(self.on_location_check,
-                                      self.on_finish_check,
-                                      self.on_deathlink_check,
-                                      self.on_deathlink_toggle,
-                                      self.on_orb_trade)
+            await self.memr.main_tick()
             await asyncio.sleep(0.1)
 
 

--- a/worlds/jakanddaxter/Client.py
+++ b/worlds/jakanddaxter/Client.py
@@ -290,9 +290,22 @@ async def run_game(ctx: JakAndDaxterContext):
             return
 
         if gk_path:
-            # Prefixing ampersand and wrapping gk_path in quotes is necessary for paths with spaces in them.
+            # Per-mod saves and settings are stored in a spot that is a little unusual to get to. We have to .. out of
+            # gk.exe and the archipelagoal folder, then traverse down to _settings/archipelagoal. Then we normalize
+            # this path and pass it in as an argument to gk.
+            config_relative_path = "../../_settings/archipelagoal"
+            config_path = os.path.normpath(
+                os.path.join(
+                    os.path.normpath(gk_path),
+                    os.path.normpath(config_relative_path)))
+
+            # Prefixing ampersand and wrapping in quotes is necessary for paths with spaces in them.
             gk_process = subprocess.Popen(
-                ["powershell.exe", f"& \"{gk_path}\"", "--game jak1", "--", "-v", "-boot", "-fakeiso", "-debug"],
+                ["powershell.exe",
+                 f"& \"{gk_path}\"",
+                 f"--config-path \"{config_path}\"",
+                 "--game jak1",
+                 "--", "-v", "-boot", "-fakeiso", "-debug"],
                 creationflags=subprocess.CREATE_NEW_CONSOLE)  # These need to be new consoles for stability.
 
     if not goalc_running:

--- a/worlds/jakanddaxter/Client.py
+++ b/worlds/jakanddaxter/Client.py
@@ -304,12 +304,12 @@ async def run_game(ctx: JakAndDaxterContext):
                          f"Please check the OpenGOAL Launcher to verify installation of the ArchipelaGOAL mod.")
             return
 
-        # IMPORTANT: Before we check the existence of the next important piece, we must ask "Are you a developer?"
-        # The OpenGOAL Compiler checks the existence of the "data" folder to determine the location of the game's code.
-        # As a developer, you would be working out of (e.g.) "ArchipelaGOAL/out/build/Release/bin" and there would be
-        # no "data" folder - the repository folder itself IS the data folder. You would have created your "iso_data"
-        # folder here as well, so we can skip the "iso_data" check. HOWEVER, for everyone who is NOT a developer,
-        # we must ensure that they copied the "iso_data" folder INTO the "data" folder per the setup instructions.
+        # IMPORTANT: Before we check the existence of the next piece, we must ask "Are you a developer?"
+        # The OpenGOAL Compiler checks the existence of the "data" folder to determine if you're running from source
+        # or from a built package. As a developer, your repository folder itself IS the data folder and the Compiler
+        # knows this. You would have created your "iso_data" folder here as well, so we can skip the "iso_data" check.
+        # HOWEVER, for everyone who is NOT a developer, we must ensure that they copied the "iso_data" folder INTO
+        # the "data" folder per the setup instructions.
         data_path = os.path.join(root_path, "data")
         if os.path.exists(data_path):
 
@@ -351,7 +351,7 @@ async def run_game(ctx: JakAndDaxterContext):
                 creationflags=subprocess.CREATE_NEW_CONSOLE)  # These need to be new consoles for stability.
 
     except AttributeError as e:
-        logger.error(f"Hosts.yaml does not contain {e.args[0]}, unable to locate game executables.")
+        logger.error(f"Host.yaml does not contain {e.args[0]}, unable to locate game executables.")
         return
 
     # Auto connect the repl and memr agents. Sleep 5 because goalc takes just a little bit of time to load,

--- a/worlds/jakanddaxter/Client.py
+++ b/worlds/jakanddaxter/Client.py
@@ -324,15 +324,17 @@ async def run_game(ctx: JakAndDaxterContext):
         # Always trust your instincts.
         if "/" not in root_path:
             msg = (f"The ArchipelaGOAL root directory contains no path. (Are you missing forward slashes?)\n"
-                   f"Please check the value of `jakanddaxter_options > root_directory` in your host.yaml file.")
+                   f"Please check that the value of 'jakanddaxter_options > root_directory' in your host.yaml file "
+                   f"is a valid existing path, and all backslashes have been replaced with forward slashes.")
             ctx.on_log_error(logger, msg)
             return
 
         # Start by checking the existence of the root directory provided in the host.yaml file.
         root_path = os.path.normpath(root_path)
         if not os.path.exists(root_path):
-            msg = (f"The ArchipelaGOAL root directory does not exist, unable to locate game executables.\n"
-                   f"Please check the value of `jakanddaxter_options > root_directory` in your host.yaml file.")
+            msg = (f"The ArchipelaGOAL root directory does not exist, unable to locate the Game and Compiler.\n"
+                   f"Please check that the value of 'jakanddaxter_options > root_directory' in your host.yaml file "
+                   f"is a valid existing path, and all backslashes have been replaced with forward slashes.")
             ctx.on_log_error(logger, msg)
             return
 
@@ -340,8 +342,9 @@ async def run_game(ctx: JakAndDaxterContext):
         gk_path = os.path.join(root_path, "gk.exe")
         goalc_path = os.path.join(root_path, "goalc.exe")
         if not os.path.exists(gk_path) or not os.path.exists(goalc_path):
-            msg = (f"The Game and Compiler executables could not be found in the ArchipelaGOAL root directory.\n"
-                   f"Please check the OpenGOAL Launcher to verify installation of the ArchipelaGOAL mod.")
+            msg = (f"The Game and Compiler could not be found in the ArchipelaGOAL root directory.\n"
+                   f"Please check the value of 'jakanddaxter_options > root_directory' in your host.yaml file, "
+                   f"and ensure that path contains gk.exe, goalc.exe, and a data folder.")
             ctx.on_log_error(logger, msg)
             return
 
@@ -360,9 +363,15 @@ async def run_game(ctx: JakAndDaxterContext):
             #  we may be able to remove this step.
             iso_data_path = os.path.join(root_path, "data", "iso_data")
             if not os.path.exists(iso_data_path):
-                msg = (f"The iso_data folder could not be found, unable to compile game.\n"
-                       f"Please copy the iso_data folder from its original location to the mod's data folder.\n"
-                       f"(See setup guide for more details.)")
+                msg = (f"The iso_data folder could not be found in the ArchipelaGOAL data directory.\n"
+                       f"Please follow these steps:\n"
+                       f"   Run the OpenGOAL Launcher, click Jak and Daxter > Advanced > Open Game Data Folder.\n"
+                       f"   Copy the iso_data folder from this location.\n"
+                       f"   Click Jak and Daxter > Features > Mods > ArchipelaGOAL > Advanced > Open Game Data Folder.\n"
+                       f"   Paste the iso_data folder in this location.\n"
+                       f"   Click Advanced > Compile. When this is done, click Continue.\n"
+                       f"   Close all launchers, games, clients, and Powershell windows, then restart Archipelago.\n"
+                       f"(See Setup Guide for more details.)")
                 ctx.on_log_error(logger, msg)
                 return
 
@@ -394,6 +403,12 @@ async def run_game(ctx: JakAndDaxterContext):
 
     except AttributeError as e:
         ctx.on_log_error(logger, f"Host.yaml does not contain {e.args[0]}, unable to locate game executables.")
+        return
+    except FileNotFoundError as e:
+        msg = (f"The ArchipelaGOAL root directory path is invalid.\n"
+               f"Please check that the value of 'jakanddaxter_options > root_directory' in your host.yaml file "
+               f"is a valid existing path, and all backslashes have been replaced with forward slashes.")
+        ctx.on_log_error(logger, msg)
         return
 
     # Auto connect the repl and memr agents. Sleep 5 because goalc takes just a little bit of time to load,

--- a/worlds/jakanddaxter/Items.py
+++ b/worlds/jakanddaxter/Items.py
@@ -16,26 +16,26 @@ cell_item_table = {
     0:  "Power Cell",
 }
 
-# Scout flies are interchangeable within their respective sets of 7. Notice the abbreviated level name after each item.
+# Scout flies are interchangeable within their respective sets of 7. Notice the level name after each item.
 # Also, notice that their Item ID equals their respective Power Cell's Location ID. This is necessary for
 # game<->archipelago communication.
 scout_item_table = {
-    95: "Scout Fly - GR",
-    75: "Scout Fly - SV",
-    7:  "Scout Fly - FJ",
-    20: "Scout Fly - SB",
-    28: "Scout Fly - MI",
-    68: "Scout Fly - FC",
-    76: "Scout Fly - RV",
-    57: "Scout Fly - PB",
-    49: "Scout Fly - LPC",
-    43: "Scout Fly - BS",
-    88: "Scout Fly - MP",
-    77: "Scout Fly - VC",
-    85: "Scout Fly - SC",
-    65: "Scout Fly - SM",
-    90: "Scout Fly - LT",
-    91: "Scout Fly - GMC",
+    95: "Scout Fly - Geyser Rock",
+    75: "Scout Fly - Sandover Village",
+    7:  "Scout Fly - Sentinel Beach",
+    20: "Scout Fly - Forbidden Jungle",
+    28: "Scout Fly - Misty Island",
+    68: "Scout Fly - Fire Canyon",
+    76: "Scout Fly - Rock Village",
+    57: "Scout Fly - Lost Precursor City",
+    49: "Scout Fly - Boggy Swamp",
+    43: "Scout Fly - Precursor Basin",
+    88: "Scout Fly - Mountain Pass",
+    77: "Scout Fly - Volcanic Crater",
+    85: "Scout Fly - Snowy Mountain",
+    65: "Scout Fly - Spider Cave",
+    90: "Scout Fly - Lava Tube",
+    91: "Scout Fly - Citadel",  # Had to shorten, it was >32 characters.
 }
 
 # Orbs are also generic and interchangeable.

--- a/worlds/jakanddaxter/Options.py
+++ b/worlds/jakanddaxter/Options.py
@@ -1,5 +1,5 @@
 from dataclasses import dataclass
-from Options import PerGameCommonOptions, StartInventoryPool, Toggle, Choice, Range, DefaultOnToggle
+from Options import PerGameCommonOptions, StartInventoryPool, Toggle, Choice, Range, DefaultOnToggle, DeathLink
 
 
 class EnableMoveRandomizer(Toggle):
@@ -174,6 +174,7 @@ class CompletionCondition(Choice):
 
 @dataclass
 class JakAndDaxterOptions(PerGameCommonOptions):
+    deathlink: DeathLink
     enable_move_randomizer: EnableMoveRandomizer
     enable_orbsanity: EnableOrbsanity
     global_orbsanity_bundle_size: GlobalOrbsanityBundleSize

--- a/worlds/jakanddaxter/Options.py
+++ b/worlds/jakanddaxter/Options.py
@@ -1,5 +1,5 @@
 from dataclasses import dataclass
-from Options import PerGameCommonOptions, StartInventoryPool, Toggle, Choice, Range, DefaultOnToggle, DeathLink
+from Options import PerGameCommonOptions, StartInventoryPool, Toggle, Choice, Range, DefaultOnToggle
 
 
 class EnableMoveRandomizer(Toggle):
@@ -174,7 +174,6 @@ class CompletionCondition(Choice):
 
 @dataclass
 class JakAndDaxterOptions(PerGameCommonOptions):
-    deathlink: DeathLink
     enable_move_randomizer: EnableMoveRandomizer
     enable_orbsanity: EnableOrbsanity
     global_orbsanity_bundle_size: GlobalOrbsanityBundleSize

--- a/worlds/jakanddaxter/client/MemoryReader.py
+++ b/worlds/jakanddaxter/client/MemoryReader.py
@@ -261,10 +261,11 @@ class JakAndDaxterMemoryReader:
                 else:
                     raise MemoryReadError(memory_version_offset, sizeof_uint32)
             except (ProcessError, MemoryReadError, WinAPIError):
-                logger.error("OpenGOAL memory structure is incompatible with current AP client!")
-                logger.error("   AP Client Version: " + str(expected_memory_version))
-                logger.error("   OpenGOAL Version: " + str(memory_version))
-                logger.error("Please verify both the OpenGOAL mod and AP Client are up-to-date, then restart both.")
+                msg = (f"The OpenGOAL memory structure is incompatible with the current AP client!\n"
+                       f"   Expected Version: {str(expected_memory_version)}\n"
+                       f"   Found Version: {str(memory_version)}\n"
+                       f"Please verify both the OpenGOAL mod and AP Client are up-to-date, then restart both.")
+                logger.error(msg)
                 self.connected = False
         else:
             logger.error("The Memory Reader is not connected!")

--- a/worlds/jakanddaxter/client/MemoryReader.py
+++ b/worlds/jakanddaxter/client/MemoryReader.py
@@ -297,10 +297,15 @@ class JakAndDaxterMemoryReader:
             else:
                 raise MemoryReadError(memory_version_offset, sizeof_uint32)
         except (ProcessError, MemoryReadError, WinAPIError):
-            msg = (f"The OpenGOAL memory structure is incompatible with the current AP client!\n"
+            msg = (f"The OpenGOAL memory structure is incompatible with the current Archipelago client!\n"
                    f"   Expected Version: {str(expected_memory_version)}\n"
                    f"   Found Version: {str(memory_version)}\n"
-                   f"Please verify both the OpenGOAL mod and AP Client are up-to-date, then restart both.")
+                   f"Please follow these steps:\n"
+                   f"   Run the OpenGOAL Launcher, click Jak and Daxter > Features > Mods > ArchipelaGOAL.\n"
+                   f"   Click Update (if one is available).\n"
+                   f"   Click Advanced > Compile. When this is done, click Continue.\n"
+                   f"   Click Versions and verify the latest version is marked 'Active'.\n"
+                   f"   Close all launchers, games, clients, and Powershell windows, then restart Archipelago.")
             self.log_error(logger, msg)
             self.connected = False
 

--- a/worlds/jakanddaxter/client/MemoryReader.py
+++ b/worlds/jakanddaxter/client/MemoryReader.py
@@ -228,7 +228,7 @@ class JakAndDaxterMemoryReader:
     async def connect(self):
         try:
             self.gk_process = pymem.Pymem("gk.exe")  # The GOAL Kernel
-            logger.info("Found the gk process: " + str(self.gk_process.process_id))
+            logger.debug("Found the gk process: " + str(self.gk_process.process_id))
         except ProcessNotFound:
             logger.error("Could not find the gk process.")
             self.connected = False
@@ -245,7 +245,7 @@ class JakAndDaxterMemoryReader:
             self.goal_address = int.from_bytes(self.gk_process.read_bytes(goal_pointer, sizeof_uint64),
                                                byteorder="little",
                                                signed=False)
-            logger.info("Found the archipelago memory address: " + str(self.goal_address))
+            logger.debug("Found the archipelago memory address: " + str(self.goal_address))
             self.connected = True
         else:
             logger.error("Could not find the archipelago memory address!")
@@ -267,7 +267,7 @@ class JakAndDaxterMemoryReader:
                 logger.error("Please verify both the OpenGOAL mod and AP Client are up-to-date, then restart both.")
                 self.connected = False
         else:
-            logger.info("The Memory Reader is not connected!")
+            logger.error("The Memory Reader is not connected!")
 
     def print_status(self):
         logger.info("Memory Reader Status:")

--- a/worlds/jakanddaxter/client/ReplClient.py
+++ b/worlds/jakanddaxter/client/ReplClient.py
@@ -1,4 +1,5 @@
 import json
+import logging
 import queue
 import time
 import struct
@@ -13,7 +14,6 @@ from pymem.exception import ProcessNotFound, ProcessError
 import asyncio
 from asyncio import StreamReader, StreamWriter, Lock
 
-from CommonClient import logger
 from NetUtils import NetworkItem
 from ..GameID import jak1_id, jak1_max
 from ..Items import item_table
@@ -23,6 +23,9 @@ from ..locs import (
     ScoutLocations as Flies,
     SpecialLocations as Specials,
     OrbCacheLocations as Caches)
+
+
+logger = logging.getLogger("ReplClient")
 
 
 @dataclass
@@ -83,12 +86,12 @@ class JakAndDaxterReplClient:
             try:
                 self.gk_process.read_bool(self.gk_process.base_address)  # Ping to see if it's alive.
             except ProcessError:
-                self.log_error("The gk process has died. Restart the game and run \"/repl connect\" again.")
+                self.log_error(logger, "The gk process has died. Restart the game and run \"/repl connect\" again.")
                 self.connected = False
             try:
                 self.goalc_process.read_bool(self.goalc_process.base_address)  # Ping to see if it's alive.
             except ProcessError:
-                self.log_error("The goalc process has died. Restart the compiler and run \"/repl connect\" again.")
+                self.log_error(logger, "The goalc process has died. Restart the compiler and run \"/repl connect\" again.")
                 self.connected = False
         else:
             return
@@ -126,7 +129,7 @@ class JakAndDaxterReplClient:
                     logger.debug(response)
                 return True
             else:
-                self.log_error(f"Unexpected response from REPL: {response}")
+                self.log_error(logger, f"Unexpected response from REPL: {response}")
                 return False
 
     async def connect(self):
@@ -134,14 +137,14 @@ class JakAndDaxterReplClient:
             self.gk_process = pymem.Pymem("gk.exe")  # The GOAL Kernel
             logger.debug("Found the gk process: " + str(self.gk_process.process_id))
         except ProcessNotFound:
-            self.log_error("Could not find the gk process.")
+            self.log_error(logger, "Could not find the gk process.")
             return
 
         try:
             self.goalc_process = pymem.Pymem("goalc.exe")  # The GOAL Compiler and REPL
             logger.debug("Found the goalc process: " + str(self.goalc_process.process_id))
         except ProcessNotFound:
-            self.log_error("Could not find the goalc process.")
+            self.log_error(logger, "Could not find the goalc process.")
             return
 
         try:
@@ -154,9 +157,9 @@ class JakAndDaxterReplClient:
             if "Connected to OpenGOAL" and "nREPL!" in welcome_message:
                 logger.debug(welcome_message)
             else:
-                self.log_error(f"Unable to connect to REPL websocket: unexpected welcome message \"{welcome_message}\"")
+                self.log_error(logger, f"Unable to connect to REPL websocket: unexpected welcome message \"{welcome_message}\"")
         except ConnectionRefusedError as e:
-            self.log_error(f"Unable to connect to REPL websocket: {e.strerror}")
+            self.log_error(logger, f"Unable to connect to REPL websocket: {e.strerror}")
             return
 
         ok_count = 0
@@ -201,7 +204,7 @@ class JakAndDaxterReplClient:
                 self.connected = False
 
         if self.connected:
-            self.log_success("The REPL is ready!")
+            self.log_success(logger, "The REPL is ready!")
 
     async def print_status(self):
         gc_proc_id = str(self.goalc_process.process_id) if self.goalc_process else "None"
@@ -223,7 +226,7 @@ class JakAndDaxterReplClient:
         last_item = str(getattr(self.item_inbox[self.inbox_index], "item")) if self.inbox_index else "None"
         msg += f"  Last item received: {last_item}\n"
         msg += f"  Did you hear the success audio cue?"
-        self.log_info(msg)
+        self.log_info(logger, msg)
 
     # To properly display in-game text, it must be alphanumeric and uppercase.
     # I also only allotted 32 bytes to each string in OpenGOAL, so we must truncate.
@@ -285,7 +288,7 @@ class JakAndDaxterReplClient:
         if ok:
             logger.debug(f"Received a Power Cell!")
         else:
-            self.log_error(f"Unable to receive a Power Cell!")
+            self.log_error(logger, f"Unable to receive a Power Cell!")
         return ok
 
     async def receive_scout_fly(self, ap_id: int) -> bool:
@@ -297,7 +300,7 @@ class JakAndDaxterReplClient:
         if ok:
             logger.debug(f"Received a {item_table[ap_id]}!")
         else:
-            self.log_error(f"Unable to receive a {item_table[ap_id]}!")
+            self.log_error(logger, f"Unable to receive a {item_table[ap_id]}!")
         return ok
 
     async def receive_special(self, ap_id: int) -> bool:
@@ -309,7 +312,7 @@ class JakAndDaxterReplClient:
         if ok:
             logger.debug(f"Received special unlock {item_table[ap_id]}!")
         else:
-            self.log_error(f"Unable to receive special unlock {item_table[ap_id]}!")
+            self.log_error(logger, f"Unable to receive special unlock {item_table[ap_id]}!")
         return ok
 
     async def receive_move(self, ap_id: int) -> bool:
@@ -321,7 +324,7 @@ class JakAndDaxterReplClient:
         if ok:
             logger.debug(f"Received the ability to {item_table[ap_id]}!")
         else:
-            self.log_error(f"Unable to receive the ability to {item_table[ap_id]}!")
+            self.log_error(logger, f"Unable to receive the ability to {item_table[ap_id]}!")
         return ok
 
     async def receive_precursor_orb(self, ap_id: int) -> bool:
@@ -333,7 +336,7 @@ class JakAndDaxterReplClient:
         if ok:
             logger.debug(f"Received {orb_amount} Precursor Orbs!")
         else:
-            self.log_error(f"Unable to receive {orb_amount} Precursor Orbs!")
+            self.log_error(logger, f"Unable to receive {orb_amount} Precursor Orbs!")
         return ok
 
     # Green eco pills are our filler item. Use the get-pickup event instead to handle being full health.
@@ -342,7 +345,7 @@ class JakAndDaxterReplClient:
         if ok:
             logger.debug(f"Received a green eco pill!")
         else:
-            self.log_error(f"Unable to receive a green eco pill!")
+            self.log_error(logger, f"Unable to receive a green eco pill!")
         return ok
 
     async def receive_deathlink(self) -> bool:
@@ -362,7 +365,7 @@ class JakAndDaxterReplClient:
         if ok:
             logger.debug(f"Received deathlink signal!")
         else:
-            self.log_error(f"Unable to receive deathlink signal!")
+            self.log_error(logger, f"Unable to receive deathlink signal!")
         return ok
 
     async def subtract_traded_orbs(self, orb_count: int) -> bool:
@@ -376,7 +379,7 @@ class JakAndDaxterReplClient:
             if ok:
                 logger.debug(f"Subtracting {orb_count} traded orbs!")
             else:
-                self.log_error(f"Unable to subtract {orb_count} traded orbs!")
+                self.log_error(logger, f"Unable to subtract {orb_count} traded orbs!")
             return ok
 
         return True
@@ -404,14 +407,14 @@ class JakAndDaxterReplClient:
             logger.debug(message + "Success!")
             status = 1
         else:
-            self.log_error(message + "Failed!")
+            self.log_error(logger, message + "Failed!")
             status = 2
 
         ok = await self.send_form(f"(ap-set-connection-status! (the uint {status}))")
         if ok:
             logger.debug(f"Connection Status {status} set!")
         else:
-            self.log_error(f"Connection Status {status} failed to set!")
+            self.log_error(logger, f"Connection Status {status} failed to set!")
 
         return ok
 

--- a/worlds/jakanddaxter/client/ReplClient.py
+++ b/worlds/jakanddaxter/client/ReplClient.py
@@ -5,7 +5,7 @@ import struct
 import random
 from dataclasses import dataclass
 from queue import Queue
-from typing import Dict, Optional
+from typing import Dict, Optional, Callable
 
 import pymem
 from pymem.exception import ProcessNotFound, ProcessError
@@ -53,10 +53,26 @@ class JakAndDaxterReplClient:
     inbox_index = 0
     json_message_queue: Queue[JsonMessageData] = queue.Queue()
 
-    def __init__(self, ip: str = "127.0.0.1", port: int = 8181):
+    # Logging callbacks
+    log_error: Callable
+    log_warn: Callable
+    log_success: Callable
+    log_info: Callable
+
+    def __init__(self,
+                 log_error_callback: Callable,
+                 log_warn_callback: Callable,
+                 log_success_callback: Callable,
+                 log_info_callback: Callable,
+                 ip: str = "127.0.0.1",
+                 port: int = 8181):
         self.ip = ip
         self.port = port
         self.lock = asyncio.Lock()
+        self.log_error = log_error_callback
+        self.log_warn = log_warn_callback
+        self.log_success = log_success_callback
+        self.log_info = log_info_callback
 
     async def main_tick(self):
         if self.initiated_connect:
@@ -67,12 +83,12 @@ class JakAndDaxterReplClient:
             try:
                 self.gk_process.read_bool(self.gk_process.base_address)  # Ping to see if it's alive.
             except ProcessError:
-                logger.error("The gk process has died. Restart the game and run \"/repl connect\" again.")
+                self.log_error("The gk process has died. Restart the game and run \"/repl connect\" again.")
                 self.connected = False
             try:
                 self.goalc_process.read_bool(self.goalc_process.base_address)  # Ping to see if it's alive.
             except ProcessError:
-                logger.error("The goalc process has died. Restart the compiler and run \"/repl connect\" again.")
+                self.log_error("The goalc process has died. Restart the compiler and run \"/repl connect\" again.")
                 self.connected = False
         else:
             return
@@ -110,7 +126,7 @@ class JakAndDaxterReplClient:
                     logger.debug(response)
                 return True
             else:
-                logger.error(f"Unexpected response from REPL: {response}")
+                self.log_error(f"Unexpected response from REPL: {response}")
                 return False
 
     async def connect(self):
@@ -118,14 +134,14 @@ class JakAndDaxterReplClient:
             self.gk_process = pymem.Pymem("gk.exe")  # The GOAL Kernel
             logger.debug("Found the gk process: " + str(self.gk_process.process_id))
         except ProcessNotFound:
-            logger.error("Could not find the gk process.")
+            self.log_error("Could not find the gk process.")
             return
 
         try:
             self.goalc_process = pymem.Pymem("goalc.exe")  # The GOAL Compiler and REPL
             logger.debug("Found the goalc process: " + str(self.goalc_process.process_id))
         except ProcessNotFound:
-            logger.error("Could not find the goalc process.")
+            self.log_error("Could not find the goalc process.")
             return
 
         try:
@@ -138,9 +154,9 @@ class JakAndDaxterReplClient:
             if "Connected to OpenGOAL" and "nREPL!" in welcome_message:
                 logger.debug(welcome_message)
             else:
-                logger.error(f"Unable to connect to REPL websocket: unexpected welcome message \"{welcome_message}\"")
+                self.log_error(f"Unable to connect to REPL websocket: unexpected welcome message \"{welcome_message}\"")
         except ConnectionRefusedError as e:
-            logger.error(f"Unable to connect to REPL websocket: {e.strerror}")
+            self.log_error(f"Unable to connect to REPL websocket: {e.strerror}")
             return
 
         ok_count = 0
@@ -185,25 +201,29 @@ class JakAndDaxterReplClient:
                 self.connected = False
 
         if self.connected:
-            logger.info("The REPL is ready!")
+            self.log_success("The REPL is ready!")
 
     async def print_status(self):
-        logger.info("REPL Status:")
-        logger.info("  REPL process ID: " + (str(self.goalc_process.process_id) if self.goalc_process else "None"))
-        logger.info("  Game process ID: " + (str(self.gk_process.process_id) if self.gk_process else "None"))
+        gc_proc_id = str(self.goalc_process.process_id) if self.goalc_process else "None"
+        gk_proc_id = str(self.gk_process.process_id) if self.gk_process else "None"
+        msg = (f"REPL Status:\n"
+               f"  REPL process ID: {gc_proc_id}\n"
+               f"  Game process ID: {gk_proc_id}\n")
         try:
             if self.reader and self.writer:
                 addr = self.writer.get_extra_info("peername")
-                logger.info("  Game websocket: " + (str(addr) if addr else "None"))
+                addr = str(addr) if addr else "None"
+                msg += f"  Game websocket: {addr}\n"
                 await self.send_form("(dotimes (i 1) "
                                      "(sound-play-by-name "
                                      "(static-sound-name \"menu-close\") "
                                      "(new-sound-id) 1024 0 0 (sound-group sfx) #t))", print_ok=False)
         except ConnectionResetError:
-            logger.warn("  Connection to the game was lost or reset!")
-        logger.info("  Did you hear the success audio cue?")
-        logger.info("  Last item received: " + (str(getattr(self.item_inbox[self.inbox_index], "item"))
-                                                if self.inbox_index else "None"))
+            msg += "  Connection to the game was lost or reset!"
+        last_item = str(getattr(self.item_inbox[self.inbox_index], "item")) if self.inbox_index else "None"
+        msg += f"  Last item received: {last_item}\n"
+        msg += f"  Did you hear the success audio cue?"
+        self.log_info(msg)
 
     # To properly display in-game text, it must be alphanumeric and uppercase.
     # I also only allotted 32 bytes to each string in OpenGOAL, so we must truncate.
@@ -265,7 +285,7 @@ class JakAndDaxterReplClient:
         if ok:
             logger.debug(f"Received a Power Cell!")
         else:
-            logger.error(f"Unable to receive a Power Cell!")
+            self.log_error(f"Unable to receive a Power Cell!")
         return ok
 
     async def receive_scout_fly(self, ap_id: int) -> bool:
@@ -277,7 +297,7 @@ class JakAndDaxterReplClient:
         if ok:
             logger.debug(f"Received a {item_table[ap_id]}!")
         else:
-            logger.error(f"Unable to receive a {item_table[ap_id]}!")
+            self.log_error(f"Unable to receive a {item_table[ap_id]}!")
         return ok
 
     async def receive_special(self, ap_id: int) -> bool:
@@ -289,7 +309,7 @@ class JakAndDaxterReplClient:
         if ok:
             logger.debug(f"Received special unlock {item_table[ap_id]}!")
         else:
-            logger.error(f"Unable to receive special unlock {item_table[ap_id]}!")
+            self.log_error(f"Unable to receive special unlock {item_table[ap_id]}!")
         return ok
 
     async def receive_move(self, ap_id: int) -> bool:
@@ -301,7 +321,7 @@ class JakAndDaxterReplClient:
         if ok:
             logger.debug(f"Received the ability to {item_table[ap_id]}!")
         else:
-            logger.error(f"Unable to receive the ability to {item_table[ap_id]}!")
+            self.log_error(f"Unable to receive the ability to {item_table[ap_id]}!")
         return ok
 
     async def receive_precursor_orb(self, ap_id: int) -> bool:
@@ -313,7 +333,7 @@ class JakAndDaxterReplClient:
         if ok:
             logger.debug(f"Received {orb_amount} Precursor Orbs!")
         else:
-            logger.error(f"Unable to receive {orb_amount} Precursor Orbs!")
+            self.log_error(f"Unable to receive {orb_amount} Precursor Orbs!")
         return ok
 
     # Green eco pills are our filler item. Use the get-pickup event instead to handle being full health.
@@ -322,7 +342,7 @@ class JakAndDaxterReplClient:
         if ok:
             logger.debug(f"Received a green eco pill!")
         else:
-            logger.error(f"Unable to receive a green eco pill!")
+            self.log_error(f"Unable to receive a green eco pill!")
         return ok
 
     async def receive_deathlink(self) -> bool:
@@ -342,7 +362,7 @@ class JakAndDaxterReplClient:
         if ok:
             logger.debug(f"Received deathlink signal!")
         else:
-            logger.error(f"Unable to receive deathlink signal!")
+            self.log_error(f"Unable to receive deathlink signal!")
         return ok
 
     async def subtract_traded_orbs(self, orb_count: int) -> bool:
@@ -356,7 +376,7 @@ class JakAndDaxterReplClient:
             if ok:
                 logger.debug(f"Subtracting {orb_count} traded orbs!")
             else:
-                logger.error(f"Unable to subtract {orb_count} traded orbs!")
+                self.log_error(f"Unable to subtract {orb_count} traded orbs!")
             return ok
 
         return True
@@ -384,14 +404,14 @@ class JakAndDaxterReplClient:
             logger.debug(message + "Success!")
             status = 1
         else:
-            logger.error(message + "Failed!")
+            self.log_error(message + "Failed!")
             status = 2
 
         ok = await self.send_form(f"(ap-set-connection-status! (the uint {status}))")
         if ok:
             logger.debug(f"Connection Status {status} set!")
         else:
-            logger.error(f"Connection Status {status} failed to set!")
+            self.log_error(f"Connection Status {status} failed to set!")
 
         return ok
 

--- a/worlds/jakanddaxter/client/ReplClient.py
+++ b/worlds/jakanddaxter/client/ReplClient.py
@@ -174,7 +174,7 @@ class JakAndDaxterReplClient:
             if await self.send_form("(set! *cheat-mode* #f)", print_ok=False):
                 ok_count += 1
 
-            # Run the retail game start sequence (while still in debug).
+            # Run the retail game start sequence (while still connected with REPL).
             if await self.send_form("(start \'play (get-continue-by-name *game-info* \"title-start\"))"):
                 ok_count += 1
 

--- a/worlds/jakanddaxter/client/ReplClient.py
+++ b/worlds/jakanddaxter/client/ReplClient.py
@@ -213,22 +213,22 @@ class JakAndDaxterReplClient:
         gc_proc_id = str(self.goalc_process.process_id) if self.goalc_process else "None"
         gk_proc_id = str(self.gk_process.process_id) if self.gk_process else "None"
         msg = (f"REPL Status:\n"
-               f"  REPL process ID: {gc_proc_id}\n"
-               f"  Game process ID: {gk_proc_id}\n")
+               f"   REPL process ID: {gc_proc_id}\n"
+               f"   Game process ID: {gk_proc_id}\n")
         try:
             if self.reader and self.writer:
                 addr = self.writer.get_extra_info("peername")
                 addr = str(addr) if addr else "None"
-                msg += f"  Game websocket: {addr}\n"
+                msg += f"   Game websocket: {addr}\n"
                 await self.send_form("(dotimes (i 1) "
                                      "(sound-play-by-name "
                                      "(static-sound-name \"menu-close\") "
                                      "(new-sound-id) 1024 0 0 (sound-group sfx) #t))", print_ok=False)
         except ConnectionResetError:
-            msg += "  Connection to the game was lost or reset!"
+            msg += f"   Connection to the game was lost or reset!"
         last_item = str(getattr(self.item_inbox[self.inbox_index], "item")) if self.inbox_index else "None"
-        msg += f"  Last item received: {last_item}\n"
-        msg += f"  Did you hear the success audio cue?"
+        msg += f"   Last item received: {last_item}\n"
+        msg += f"   Did you hear the success audio cue?"
         self.log_info(logger, msg)
 
     # To properly display in-game text, it must be alphanumeric and uppercase.
@@ -402,10 +402,10 @@ class JakAndDaxterReplClient:
                                   f"(the float {lt_count}) (the float {ct_amount}) "
                                   f"(the float {ot_amount}) (the uint {goal_id}))")
         message = (f"Setting options: \n"
-                   f"    Orbsanity Option {os_option}, Orbsanity Bundle {os_bundle}, \n"
-                   f"    FC Cell Count {fc_count}, MP Cell Count {mp_count}, \n"
-                   f"    LT Cell Count {lt_count}, Citizen Orb Amt {ct_amount}, \n"
-                   f"    Oracle Orb Amt {ot_amount}, Completion GOAL {goal_id}... ")
+                   f"   Orbsanity Option {os_option}, Orbsanity Bundle {os_bundle}, \n"
+                   f"   FC Cell Count {fc_count}, MP Cell Count {mp_count}, \n"
+                   f"   LT Cell Count {lt_count}, Citizen Orb Amt {ct_amount}, \n"
+                   f"   Oracle Orb Amt {ot_amount}, Completion GOAL {goal_id}... ")
         if ok:
             logger.debug(message + "Success!")
             status = 1

--- a/worlds/jakanddaxter/client/ReplClient.py
+++ b/worlds/jakanddaxter/client/ReplClient.py
@@ -57,7 +57,6 @@ class JakAndDaxterReplClient:
         self.ip = ip
         self.port = port
         self.lock = asyncio.Lock()
-        self.connect()
 
     async def main_tick(self):
         if self.initiated_connect:

--- a/worlds/jakanddaxter/client/ReplClient.py
+++ b/worlds/jakanddaxter/client/ReplClient.py
@@ -57,10 +57,11 @@ class JakAndDaxterReplClient:
     json_message_queue: Queue[JsonMessageData] = queue.Queue()
 
     # Logging callbacks
-    log_error: Callable
-    log_warn: Callable
-    log_success: Callable
-    log_info: Callable
+    # These will write to the provided logger, as well as the Client GUI with color markup.
+    log_error: Callable    # Red
+    log_warn: Callable     # Orange
+    log_success: Callable  # Green
+    log_info: Callable     # White (default)
 
     def __init__(self,
                  log_error_callback: Callable,
@@ -91,7 +92,8 @@ class JakAndDaxterReplClient:
             try:
                 self.goalc_process.read_bool(self.goalc_process.base_address)  # Ping to see if it's alive.
             except ProcessError:
-                self.log_error(logger, "The goalc process has died. Restart the compiler and run \"/repl connect\" again.")
+                self.log_error(logger,
+                               "The goalc process has died. Restart the compiler and run \"/repl connect\" again.")
                 self.connected = False
         else:
             return
@@ -157,7 +159,8 @@ class JakAndDaxterReplClient:
             if "Connected to OpenGOAL" and "nREPL!" in welcome_message:
                 logger.debug(welcome_message)
             else:
-                self.log_error(logger, f"Unable to connect to REPL websocket: unexpected welcome message \"{welcome_message}\"")
+                self.log_error(logger,
+                               f"Unable to connect to REPL websocket: unexpected welcome message \"{welcome_message}\"")
         except ConnectionRefusedError as e:
             self.log_error(logger, f"Unable to connect to REPL websocket: {e.strerror}")
             return
@@ -277,7 +280,7 @@ class JakAndDaxterReplClient:
         elif ap_id == jak1_max:
             await self.receive_green_eco()  # Ponder why I chose to do ID's this way.
         else:
-            raise KeyError(f"Tried to receive item with unknown AP ID {ap_id}.")
+            self.log_error(logger, f"Tried to receive item with unknown AP ID {ap_id}!")
 
     async def receive_power_cell(self, ap_id: int) -> bool:
         cell_id = Cells.to_game_id(ap_id)


### PR DESCRIPTION
Please format your title with what portion of the project this pull request is
targeting and what it's changing.

ex. "MyGame4: implement new game" or "Docs: add new guide for customizing MyGame3"

## What is this fixing or adding?
- Added version checking to the Archipelago memory structure. This will alert users if their current mod is incompatible with their current client.
- Added color logging to the client that alerts users to changes to the client and its agents (errors, warnings, info, etc).
- Launching the mod from the client now uses the proper mod-specific saves and settings folder.
- Refactor client agents to have more logging, more informative user messages, and rearranging how the agents call back to the client.
- Renamed the Scout Fly items to remove the level abbreviations. This was causing confusion even for the seasoned Jak speedrunners.

## How was this tested?
JacobMIX was able to take this APWORLD and try it against his current mod installation. As expected, it warned him against the usual pitfalls new players (or updating players) see. He also received the code for the new mod, and the new APWORLD performed as expected in this situation.

## If this makes graphical changes, please attach screenshots.
![image](https://github.com/user-attachments/assets/06b8c0e1-e79f-4ac7-9ee9-1d225288579f)
![image](https://github.com/user-attachments/assets/53256213-9085-456b-866d-ecff780e35ad)
![image](https://github.com/user-attachments/assets/c3870f13-e321-483e-8be2-7f7cca9021b5)
