### PR TITLE
Stellar Messaging

### DIFF
--- a/worlds/jakanddaxter/Client.py
+++ b/worlds/jakanddaxter/Client.py
@@ -302,7 +302,7 @@ class JakAndDaxterContext(CommonContext):
 async def run_game(ctx: JakAndDaxterContext):
 
     # These may already be running. If they are not running, try to start them.
-    # TODO - Support other OS's. cmd for some reason does not work with goalc. Pymem is Windows-only.
+    # TODO - Support other OS's. Pymem is Windows-only.
     gk_running = False
     try:
         pymem.Pymem("gk.exe")  # The GOAL Kernel
@@ -370,7 +370,7 @@ async def run_game(ctx: JakAndDaxterContext):
                        f"   Click Jak and Daxter > Features > Mods > ArchipelaGOAL > Advanced > Open Game Data Folder.\n"
                        f"   Paste the iso_data folder in this location.\n"
                        f"   Click Advanced > Compile. When this is done, click Continue.\n"
-                       f"   Close all launchers, games, clients, and Powershell windows, then restart Archipelago.\n"
+                       f"   Close all launchers, games, clients, and console windows, then restart Archipelago.\n"
                        f"(See Setup Guide for more details.)")
                 ctx.on_log_error(logger, msg)
                 return
@@ -386,20 +386,23 @@ async def run_game(ctx: JakAndDaxterContext):
                     os.path.normpath(root_path),
                     os.path.normpath(config_relative_path)))
 
-            # Prefixing ampersand and wrapping in quotes is necessary for paths with spaces in them.
-            gk_process = subprocess.Popen(
-                ["powershell.exe",
-                 f"& \"{gk_path}\"",
-                 f"--config-path \"{config_path}\"",
-                 "--game jak1",
-                 "--", "-v", "-boot", "-fakeiso", "-debug"],
-                creationflags=subprocess.CREATE_NEW_CONSOLE)  # These need to be new consoles for stability.
+            # The game freezes if text is inadvertently selected in the stdout/stderr data streams.
+            # We want to pipe those streams to a file, so we don't have to worry about accidental user interaction.
+            # It also means we don't clutter the screen with another console.
+            log_path = os.path.join(Utils.user_path("logs"), "JakAndDaxterGame.txt")
+            log_path = os.path.normpath(log_path)
+            with open(log_path, "w") as log_file:
+                gk_process = subprocess.Popen(
+                    [gk_path, "--game", "jak1",
+                     "--config-path", config_path, "--", "-v", "-boot", "-fakeiso", "-debug"],
+                    stdout=log_file,
+                    stderr=log_file)
 
         if not goalc_running:
-            # Prefixing ampersand and wrapping goalc_path in quotes is necessary for paths with spaces in them.
+            # This needs to be a new console. The REPL console cannot share a window with any other process.
             goalc_process = subprocess.Popen(
-                ["powershell.exe", f"& \"{goalc_path}\"", "--game jak1"],
-                creationflags=subprocess.CREATE_NEW_CONSOLE)  # These need to be new consoles for stability.
+                [goalc_path, "--game", "jak1"],
+                creationflags=subprocess.CREATE_NEW_CONSOLE)
 
     except AttributeError as e:
         ctx.on_log_error(logger, f"Host.yaml does not contain {e.args[0]}, unable to locate game executables.")

--- a/worlds/jakanddaxter/client/MemoryReader.py
+++ b/worlds/jakanddaxter/client/MemoryReader.py
@@ -225,7 +225,15 @@ class JakAndDaxterMemoryReader:
             try:
                 self.gk_process.read_bool(self.gk_process.base_address)  # Ping to see if it's alive.
             except (ProcessError, MemoryReadError, WinAPIError):
-                self.log_error(logger, "The gk process has died. Restart the game and run \"/memr connect\" again.")
+                msg = (f"Error reading game memory! (Did the game crash?)\n"
+                       f"Please close all open windows and reopen the Jak and Daxter Client "
+                       f"from the Archipelago Launcher.\n"
+                       f"If the game and compiler do not restart automatically, please follow these steps:\n"
+                       f"   Run the OpenGOAL Launcher, click Jak and Daxter > Features > Mods > ArchipelaGOAL.\n"
+                       f"   Then click Advanced > Play in Debug Mode.\n"
+                       f"   Then click Advanced > Open REPL.\n"
+                       f"   Then close and reopen the Jak and Daxter Client from the Archipelago Launcher.")
+                self.log_error(logger, msg)
                 self.connected = False
         else:
             return
@@ -264,7 +272,7 @@ class JakAndDaxterMemoryReader:
             self.gk_process = pymem.Pymem("gk.exe")  # The GOAL Kernel
             logger.debug("Found the gk process: " + str(self.gk_process.process_id))
         except ProcessNotFound:
-            self.log_error(logger, "Could not find the gk process.")
+            self.log_error(logger, "Could not find the game process.")
             self.connected = False
             return
 
@@ -426,7 +434,15 @@ class JakAndDaxterMemoryReader:
                 self.log_success(logger, "Congratulations! You finished the game!")
 
         except (ProcessError, MemoryReadError, WinAPIError):
-            self.log_error(logger, "The gk process has died. Restart the game and run \"/memr connect\" again.")
+            msg = (f"Error reading game memory! (Did the game crash?)\n"
+                   f"Please close all open windows and reopen the Jak and Daxter Client "
+                   f"from the Archipelago Launcher.\n"
+                   f"If the game and compiler do not restart automatically, please follow these steps:\n"
+                   f"   Run the OpenGOAL Launcher, click Jak and Daxter > Features > Mods > ArchipelaGOAL.\n"
+                   f"   Then click Advanced > Play in Debug Mode.\n"
+                   f"   Then click Advanced > Open REPL.\n"
+                   f"   Then close and reopen the Jak and Daxter Client from the Archipelago Launcher.")
+            self.log_error(logger, msg)
             self.connected = False
 
         return self.location_outbox

--- a/worlds/jakanddaxter/client/MemoryReader.py
+++ b/worlds/jakanddaxter/client/MemoryReader.py
@@ -28,7 +28,7 @@ sizeof_float = 4
 # *****************************************************************************
 # **** This number must match (-> *ap-info-jak1* version) in ap-struct.gc! ****
 # *****************************************************************************
-expected_memory_version = 2
+expected_memory_version = 3
 
 
 # IMPORTANT: OpenGOAL memory structures are particular about the alignment, in memory, of member elements according to
@@ -305,7 +305,7 @@ class JakAndDaxterMemoryReader:
                    f"   Click Update (if one is available).\n"
                    f"   Click Advanced > Compile. When this is done, click Continue.\n"
                    f"   Click Versions and verify the latest version is marked 'Active'.\n"
-                   f"   Close all launchers, games, clients, and Powershell windows, then restart Archipelago.")
+                   f"   Close all launchers, games, clients, and console windows, then restart Archipelago.")
             self.log_error(logger, msg)
             self.connected = False
 
@@ -404,7 +404,7 @@ class JakAndDaxterMemoryReader:
                             bundle_ap_id = Orbs.to_ap_id(Orbs.find_address(level, bundle, bundle_size))
                             if bundle_ap_id not in self.location_outbox:
                                 self.location_outbox.append(bundle_ap_id)
-                                logger.debug("Checked orb bundle: " + str(bundle_ap_id))
+                                logger.debug(f"Checked orb bundle: L{level} {bundle}")
 
             # Global Orbsanity option. Index 16 refers to all orbs found regardless of level.
             if orbsanity_option == 2:
@@ -418,7 +418,7 @@ class JakAndDaxterMemoryReader:
                         bundle_ap_id = Orbs.to_ap_id(Orbs.find_address(16, bundle, bundle_size))
                         if bundle_ap_id not in self.location_outbox:
                             self.location_outbox.append(bundle_ap_id)
-                            logger.debug("Checked orb bundle: " + str(bundle_ap_id))
+                            logger.debug(f"Checked orb bundle: G {bundle}")
 
             completed = self.read_goal_address(completed_offset, sizeof_uint8)
             if completed > 0 and not self.finished_game:

--- a/worlds/jakanddaxter/client/ReplClient.py
+++ b/worlds/jakanddaxter/client/ReplClient.py
@@ -245,7 +245,7 @@ class JakAndDaxterReplClient:
 
     # OpenGOAL can handle both its own string datatype and C-like character pointers (charp).
     async def write_game_text(self, data: JsonMessageData):
-        logger.debug(f"Sending info to in-game display!")
+        logger.debug(f"Sending info to the in-game messenger!")
         body = ""
         if data.my_item_name and data.my_item_finder:
             body += (f" (append-messages (-> *ap-messenger* 0) \'recv "

--- a/worlds/jakanddaxter/client/ReplClient.py
+++ b/worlds/jakanddaxter/client/ReplClient.py
@@ -87,13 +87,28 @@ class JakAndDaxterReplClient:
             try:
                 self.gk_process.read_bool(self.gk_process.base_address)  # Ping to see if it's alive.
             except ProcessError:
-                self.log_error(logger, "The gk process has died. Restart the game and run \"/repl connect\" again.")
+                msg = (f"Error reading game memory! (Did the game crash?)\n"
+                       f"Please close all open windows and reopen the Jak and Daxter Client "
+                       f"from the Archipelago Launcher.\n"
+                       f"If the game and compiler do not restart automatically, please follow these steps:\n"
+                       f"   Run the OpenGOAL Launcher, click Jak and Daxter > Features > Mods > ArchipelaGOAL.\n"
+                       f"   Then click Advanced > Play in Debug Mode.\n"
+                       f"   Then click Advanced > Open REPL.\n"
+                       f"   Then close and reopen the Jak and Daxter Client from the Archipelago Launcher.")
+                self.log_error(logger, msg)
                 self.connected = False
             try:
                 self.goalc_process.read_bool(self.goalc_process.base_address)  # Ping to see if it's alive.
             except ProcessError:
-                self.log_error(logger,
-                               "The goalc process has died. Restart the compiler and run \"/repl connect\" again.")
+                msg = (f"Error sending data to compiler! (Did the compiler crash?)\n"
+                       f"Please close all open windows and reopen the Jak and Daxter Client "
+                       f"from the Archipelago Launcher.\n"
+                       f"If the game and compiler do not restart automatically, please follow these steps:\n"
+                       f"   Run the OpenGOAL Launcher, click Jak and Daxter > Features > Mods > ArchipelaGOAL.\n"
+                       f"   Then click Advanced > Play in Debug Mode.\n"
+                       f"   Then click Advanced > Open REPL.\n"
+                       f"   Then close and reopen the Jak and Daxter Client from the Archipelago Launcher.")
+                self.log_error(logger, msg)
                 self.connected = False
         else:
             return
@@ -139,14 +154,14 @@ class JakAndDaxterReplClient:
             self.gk_process = pymem.Pymem("gk.exe")  # The GOAL Kernel
             logger.debug("Found the gk process: " + str(self.gk_process.process_id))
         except ProcessNotFound:
-            self.log_error(logger, "Could not find the gk process.")
+            self.log_error(logger, "Could not find the game process.")
             return
 
         try:
             self.goalc_process = pymem.Pymem("goalc.exe")  # The GOAL Compiler and REPL
             logger.debug("Found the goalc process: " + str(self.goalc_process.process_id))
         except ProcessNotFound:
-            self.log_error(logger, "Could not find the goalc process.")
+            self.log_error(logger, "Could not find the compiler process.")
             return
 
         try:

--- a/worlds/jakanddaxter/client/ReplClient.py
+++ b/worlds/jakanddaxter/client/ReplClient.py
@@ -244,22 +244,16 @@ class JakAndDaxterReplClient:
         self.json_message_queue.put(JsonMessageData(my_item_name, my_item_finder, their_item_name, their_item_owner))
 
     # OpenGOAL can handle both its own string datatype and C-like character pointers (charp).
-    # So for the game to constantly display this information in the HUD, we have to write it
-    # to a memory address as a char*.
     async def write_game_text(self, data: JsonMessageData):
         logger.debug(f"Sending info to in-game display!")
         body = ""
-        if data.my_item_name:
-            body += (f" (charp<-string (-> *ap-info-jak1* my-item-name)"
-                     f" {self.sanitize_game_text(data.my_item_name)})")
-        if data.my_item_finder:
-            body += (f" (charp<-string (-> *ap-info-jak1* my-item-finder)"
+        if data.my_item_name and data.my_item_finder:
+            body += (f" (append-messages (-> *ap-messenger* 0) \'recv "
+                     f" {self.sanitize_game_text(data.my_item_name)} "
                      f" {self.sanitize_game_text(data.my_item_finder)})")
-        if data.their_item_name:
-            body += (f" (charp<-string (-> *ap-info-jak1* their-item-name)"
-                     f" {self.sanitize_game_text(data.their_item_name)})")
-        if data.their_item_owner:
-            body += (f" (charp<-string (-> *ap-info-jak1* their-item-owner)"
+        if data.their_item_name and data.their_item_owner:
+            body += (f" (append-messages (-> *ap-messenger* 0) \'sent "
+                     f" {self.sanitize_game_text(data.their_item_name)} "
                      f" {self.sanitize_game_text(data.their_item_owner)})")
         await self.send_form(f"(begin {body} (none))", print_ok=False)
 

--- a/worlds/jakanddaxter/docs/setup_en.md
+++ b/worlds/jakanddaxter/docs/setup_en.md
@@ -10,26 +10,68 @@ At this time, this method of setup works on Windows only, but Linux support is a
 
 ## Installation via OpenGOAL Launcher
 
-- Follow the installation process for the official OpenGOAL Launcher. See [here](https://opengoal.dev/docs/usage/installation).
-    - **You must set up a vanilla installation of Jak and Daxter before you can install mods for it.**
+**You must set up a vanilla installation of Jak and Daxter before you can install mods for it.**
+
+- Follow the installation process for the official OpenGOAL Launcher. See [here](https://opengoal.dev/docs/usage/installation). 
 - Follow the setup process for adding mods to the OpenGOAL Launcher. See [here](https://jakmods.dev/).
 - Run the OpenGOAL Launcher (if you had it open before, close it and reopen it).
 - Click the Jak and Daxter logo on the left sidebar.
 - Click `Features` in the bottom right corner, then click `Mods`.
 - Under `Available Mods`, click `ArchipelaGOAL`. The mod should begin installing. When it is done, click `Continue` in the bottom right corner.
-- Once you are back in the mod menu, click on `ArchipelaGOAL` from the `Installed Mods` list.
-- **As a temporary measure, you need to copy the extracted ISO data to the mod directory so the compiler will work properly.**
-    - If you have the NTSC version of the game, follow the `The Game Fails To Load The Title Screen` instructions below.
-    - If you have the PAL version of the game, follow the `Special PAL Instructions` instructions **instead.**
-- **If you installed the OpenGOAL Launcher to a non-default directory, you must now follow these steps.**
-    - Run the OpenGOAL Launcher (if you had it open before, close it and reopen it).
-    - Click the Jak and Daxter logo on the left sidebar.
-    - Click `Features` in the bottom right corner, then click `Mods`.
-    - Under `Installed Mods`, then click `ArchipelaGOAL`, then click `Advanced` in the bottom right corner, then click `Open Game Data Folder`. You should see a new File Explorer open to that directory.
-    - In the File Explorer, go to the parent directory called `archipelagoal`, and you should see the `gk.exe` and `goalc.exe` executables. Take note of this directory.
-    - Run the Archipelago Launcher, then click on `Open host.yaml`. You should see a new text editor open that file.
-    - Search for `jakanddaxter_options`, then find the `root_directory` entry underneath it. Paste the directory you noted earlier (the one containing gk.exe and goalc.exe) inside the double quotes. 
-    - **MAKE SURE YOU CHANGE ALL BACKSLASHES `\ ` TO FORWARD SLASHES `/`.**
+
+### For NTSC versions of the game, follow these steps.
+
+- Click the Jak and Daxter logo on the left sidebar, then click `Advanced`, then click `Open Game Data Folder`. Copy the `iso_data` folder from this directory.
+- Back in the OpenGOAL Launcher, click the Jak and Daxter logo on the left sidebar.
+- Click `Features` in the bottom right corner, then click `Mods`, then under `Installed Mods`, click `ArchipelaGOAL`.
+- In the bottom right corner, click `Advanced`, then click `Open Game Data Folder`.
+- Paste the `iso_data` folder you copied earlier.
+- Back in the OpenGOAL Launcher, click the Jak and Daxter logo on the left sidebar.
+- Click `Features` in the bottom right corner, then click `Mods`, then under `Installed Mods`, click `ArchipelaGOAL`.
+- In the bottom right corner, click `Advanced`, then click `Compile`.
+
+### For PAL versions of the game, follow these steps.
+
+PAL versions of the game seem to require additional troubleshooting/setup in order to work properly.
+Below are some instructions that may help. 
+If you see `-- Compilation Error! --` after pressing `Compile` or Launching the ArchipelaGOAL mod, try these steps.
+
+- Remove these folders if you have them: 
+    - `<opengoal active version directory>/iso_data`
+    - `<archipelagoal directory>/iso_data`
+    - `<archipelagoal directory>/data/iso_data`
+- Place your Jak1 ISO in `<archipelagoal directory>` and rename it to `JakAndDaxter.iso`
+- Type `cmd` in Windows search, right click `Command Prompt`, and pick `Run as Administrator`
+- Run `cd <archipelagoal directory>`
+- Then run `.\extractor.exe --extract --extract-path .\data\iso_data "JakAndDaxter.iso"` 
+    - This command should end by saying `Uses Decompiler Config Version - ntsc_v1` or `... - pal`. Take note of this message.
+- If you saw `ntsc_v1`:
+    - In cmd, run `.\decompiler.exe data\decompiler\config\jak1\jak1_config.jsonc --version "ntsc_v1" data\iso_data data\decompiler_out`
+- If you saw `pal`:
+    - Rename `<archipelagoal directory>\data\iso_data\jak1` to `jak1_pal`
+    - Back in cmd, run `.\decompiler.exe data\decompiler\config\jak1\jak1_config.jsonc --version "pal" data\iso_data data\decompiler_out`
+    - Rename `<archipelagoal directory>\data\iso_data\jak1_pal` back to `jak1`
+    - Rename `<archipelagoal directory>\data\decompiler_out\jak1_pal` back to `jak1`
+- Open a **brand new** console window and launch the compiler:
+    - `cd <archipelagoal directory>`
+    - `.\goalc.exe --user-auto --game jak1`
+    - From the compiler (in the same window): `(mi)`. This should compile the game. **Note that the parentheses are important.** 
+    - **Don't close this first terminal, you will need it at the end.**
+- Then, open **another brand new** console window and execute the game:
+    - `cd <archipelagoal directory>`
+    - `.\gk.exe -v --game jak1 -- -boot -fakeiso -debug`
+- Finally, **from the first console still in the GOALC compiler**, connect to the game: `(lt)`.
+
+### For OpenGOAL Launchers installed to a non-default directory, follow these steps.
+
+- Run the OpenGOAL Launcher (if you had it open before, close it and reopen it).
+- Click the Jak and Daxter logo on the left sidebar.
+- Click `Features` in the bottom right corner, then click `Mods`.
+- Under `Installed Mods`, then click `ArchipelaGOAL`, then click `Advanced` in the bottom right corner, then click `Open Game Data Folder`. You should see a new File Explorer open to that directory.
+- In the File Explorer, go to the parent directory called `archipelagoal`, and you should see the `gk.exe` and `goalc.exe` executables. Take note of this directory.
+- Run the Archipelago Launcher, then click on `Open host.yaml`. You should see a new text editor open that file.
+- Search for `jakanddaxter_options`, then find the `root_directory` entry underneath it. Paste the directory you noted earlier (the one containing gk.exe and goalc.exe) inside the double quotes. 
+- **MAKE SURE YOU CHANGE ALL BACKSLASHES `\ ` TO FORWARD SLASHES `/`.**
 
 ```
 jakanddaxter_options:
@@ -38,7 +80,7 @@ jakanddaxter_options:
   root_directory: "%programfiles%/OpenGOAL-Launcher/features/jak1/mods/JakMods/archipelagoal"
 ```
 
-  - Save the file and close it.
+- Save the file and close it.
 - **DO NOT PLAY AN ARCHIPELAGO GAME THROUGH THE OPENGOAL LAUNCHER.** The Jak and Daxter Client should handle everything for you (see below).
 
 ## Updates and New Releases via OpenGOAL Launcher
@@ -84,13 +126,13 @@ If you are in the middle of an async game, and you do not want to update the mod
 
 ### The Game Fails To Load The Title Screen
 
-You may start the game via the Text Client, but it never loads in the title screen. Check the Compiler window and you may see red and yellow errors like this.
+You may start the game via the Text Client, but it never loads in the title screen. Check the Compiler window: you may see red and yellow errors like this.
 
 ```
 -- Compilation Error! --
 ```
 
-If this happens, follow these instructions. If you are using a PAL version of the game, you should skip these instructions and follow `Special PAL Instructions` below.
+If this happens, follow these instructions. If you are using a PAL version of the game, you should skip these instructions and follow the `Special PAL Instructions` above.
 
 - Run the OpenGOAL Launcher (if you had it open before, close it and reopen it).
 - Click the Jak and Daxter logo on the left sidebar, then click `Advanced`, then click `Open Game Data Folder`. Copy the `iso_data` folder from this directory.
@@ -102,64 +144,25 @@ If this happens, follow these instructions. If you are using a PAL version of th
 - Click `Features` in the bottom right corner, then click `Mods`, then under `Installed Mods`, click `ArchipelaGOAL`.
 - In the bottom right corner, click `Advanced`, then click `Compile`.
 
-### The Text Client Says "The <gk/goalc> process has died"
+### The Text Client Says "Error reading game memory!" or "Error sending data to compiler"
 
-If at any point the text client says `The <gk/goalc> process has died`, you will need to restart the appropriate application.
+If at any point the text client says this, you will need to restart the **all** of these applications.
 
+- Close all open windows: the client, the compiler, and the game.
 - Run the OpenGOAL Launcher, then click `Features`, then click `Mods`, then click `ArchipelaGOAL`.
-- If the gk process died, click `Advanced`, then click `Play in Debug Mode`.
-- If the goalc process died, click `Advanced`, then click `Open REPL`.
-- Then enter the following commands into the text client to reconnect everything to the game.
-    - `/repl connect`
-    - `/memr connect`
+- Click `Advanced`, then click `Play in Debug Mode`.
+- Click `Advanced`, then click `Open REPL`.
+- Then close and reopen the Jak and Daxter Client from the Archipelago Launcher.
 - Once these are done, you can enter `/repl status` and `/memr status` in the text client to verify.
-
-### The Game Freezes On The Same Two Frames, But The Music Is Still Playing
-
-If the game freezes by replaying the same two frames over and over, but the music still runs in the background, you may have accidentally interacted with the console windows in the background. They halt the game if you scroll up in them, highlight text in them, etc.
-
-- To unfreeze the game, scroll to the very bottom of the console window and right click. That will release console from your control and allow the game to continue.
-- It is recommended to keep these windows minimized and out of your way.
 
 ### The Client Cannot Open A REPL Connection
 
 If the client cannot open a REPL connection to the game, you may need to ensure you are not hosting anything on ports `8181` and `8112`.
 
-### Special PAL Instructions
-
-PAL versions of the game seem to require additional troubleshooting/setup in order to work properly. Below are some instructions that may help.
-If you see `-- Compilation Error! --` after pressing `Compile` or Launching the ArchipelaGOAL mod, try these steps.
-
-- Remove these folders if you have them: 
-    - `<opengoal active version directory>/iso_data`
-    - `<archipelagoal directory>/iso_data`
-    - `<archipelagoal directory>/data/iso_data`
-- Place your Jak1 ISO in `<archipelagoal directory>` and rename it to `JakAndDaxter.iso`
-- Type `cmd` in Windows search, right click `Command Prompt`, and pick `Run as Administrator`
-- Run `cd <archipelagoal directory>`
-- Then run `.\extractor.exe --extract --extract-path .\data\iso_data "JakAndDaxter.iso"` 
-    - This command should end by saying `Uses Decompiler Config Version - ntsc_v1` or `... - pal`. Take note of this message.
-- If you saw `ntsc_v1`:
-    - In cmd, run `.\decompiler.exe data\decompiler\config\jak1\jak1_config.jsonc --version "ntsc_v1" data\iso_data data\decompiler_out`
-- If you saw `pal`:
-    - Rename `<archipelagoal directory>\data\iso_data\jak1` to `jak1_pal`
-    - Back in cmd, run `.\decompiler.exe data\decompiler\config\jak1\jak1_config.jsonc --version "pal" data\iso_data data\decompiler_out`
-    - Rename `<archipelagoal directory>\data\iso_data\jak1_pal` back to `jak1`
-    - Rename `<archipelagoal directory>\data\decompiler_out\jak1_pal` back to `jak1`
-- Open a **brand new** console window and launch the compiler:
-    - `cd <archipelagoal directory>`
-    - `.\goalc.exe --user-auto --game jak1`
-    - From the compiler (in the same window): `(mi)`. This should compile the game. **Note that the parentheses are important.** 
-    - **Don't close this first terminal, you will need it at the end.**
-- Then, open **another brand new** console window and execute the game:
-    - `cd <archipelagoal directory>`
-    - `.\gk.exe -v --game jak1 -- -boot -fakeiso -debug`
-- Finally, **from the first console still in the GOALC compiler**, connect to the game: `(lt)`.
-
 ## Known Issues
 
-- The game needs to boot in debug mode in order to allow the REPL to connect to it. We disable debug mode once we connect to the AP server.
-- The REPL console window is orphaned once you close the game - you will have to kill it manually when you stop playing.
+- The game needs to boot in debug mode in order to allow the compiler to connect to it. **Clicking "Play" on the mod page in the OpenGOAL Launcher will not work.**
+- The Compiler console window is orphaned once you close the game - you will have to kill it manually when you stop playing.
 - The console windows cannot be run as background processes due to how the REPL works, so the best we can do is minimize them.
 - Orbsanity checks may show up out of order in the text client.
 - Large item releases may take up to several minutes for the game to process them all. 

--- a/worlds/jakanddaxter/docs/setup_en.md
+++ b/worlds/jakanddaxter/docs/setup_en.md
@@ -51,7 +51,8 @@ If you are in the middle of an async game, and you do not want to update the mod
 - Under `Installed Mods`, click `ArchipelaGOAL`.
 - Click `Update` to download and install any new updates that have been released.
 - You can verify your version by clicking `Versions`. The version you are using will say `(Active)` next to it.
-- **After the update is installed, you must click `Advanced`, then click `Compile` to make the update take effect.**
+- **After the update is installed, you will need to copy your `iso_data` folder to the mod's data directory, as you did during install.**
+- **Then you must click `Advanced`, then click `Compile` to make the update take effect.**
 
 ## Starting a Game
 
@@ -59,14 +60,14 @@ If you are in the middle of an async game, and you do not want to update the mod
 
 - Run the Archipelago Launcher.
 - From the right-most list, find and click `Jak and Daxter Client`.
-- 4 new windows should appear:
-  - Two powershell windows will open to run the OpenGOAL compiler and the game. They should take about 30 seconds to compile.
+- 3 new windows should appear:
+  - The OpenGOAL compiler will launch and compile the game. They should take about 30 seconds to compile.
       - You should hear a musical cue to indicate the compilation was a success. If you do not, see the Troubleshooting section.
   - The game window itself will launch, and Jak will be standing outside Samos's Hut. 
       - Once compilation is complete, the title intro sequence will start.
   - Finally, the Archipelago text client will open.
       - If you see `The REPL is ready!` and `The Memory Reader is ready!` then that should indicate a successful startup.
-- You can *minimize* the 2 powershell windows, **BUT DO NOT CLOSE THEM.** They are required for Archipelago and the game to communicate with each other.
+- You can *minimize* the Compiler window, **BUT DO NOT CLOSE IT.** It is required for Archipelago and the game to communicate with each other.
 - Use the text client to connect to the Archipelago server while on the title screen. This will communicate your current settings to the game.
 - Start a new game in the title screen, and play through the cutscenes.
 - Once you reach Geyser Rock, you can start the game!
@@ -115,9 +116,9 @@ If at any point the text client says `The <gk/goalc> process has died`, you will
 
 ### The Game Freezes On The Same Two Frames, But The Music Is Still Playing
 
-If the game freezes by replaying the same two frames over and over, but the music still runs in the background, you may have accidentally interacted with the powershell windows in the background. They halt the game if you scroll up in them, highlight text in them, etc.
+If the game freezes by replaying the same two frames over and over, but the music still runs in the background, you may have accidentally interacted with the console windows in the background. They halt the game if you scroll up in them, highlight text in them, etc.
 
-- To unfreeze the game, scroll to the very bottom of the powershell window and right click. That will release powershell from your control and allow the game to continue.
+- To unfreeze the game, scroll to the very bottom of the console window and right click. That will release console from your control and allow the game to continue.
 - It is recommended to keep these windows minimized and out of your way.
 
 ### The Client Cannot Open A REPL Connection
@@ -145,20 +146,20 @@ If you see `-- Compilation Error! --` after pressing `Compile` or Launching the 
     - Back in cmd, run `.\decompiler.exe data\decompiler\config\jak1\jak1_config.jsonc --version "pal" data\iso_data data\decompiler_out`
     - Rename `<archipelagoal directory>\data\iso_data\jak1_pal` back to `jak1`
     - Rename `<archipelagoal directory>\data\decompiler_out\jak1_pal` back to `jak1`
-- Open a **brand new** Powershell window and launch the compiler:
+- Open a **brand new** console window and launch the compiler:
     - `cd <archipelagoal directory>`
     - `.\goalc.exe --user-auto --game jak1`
     - From the compiler (in the same window): `(mi)`. This should compile the game. **Note that the parentheses are important.** 
     - **Don't close this first terminal, you will need it at the end.**
-- Then, open **another brand new** Powershell window and execute the game:
+- Then, open **another brand new** console window and execute the game:
     - `cd <archipelagoal directory>`
     - `.\gk.exe -v --game jak1 -- -boot -fakeiso -debug`
-- Finally, **from the first Powershell still in the GOALC compiler**, connect to the game: `(lt)`.
+- Finally, **from the first console still in the GOALC compiler**, connect to the game: `(lt)`.
 
 ## Known Issues
 
 - The game needs to boot in debug mode in order to allow the REPL to connect to it. We disable debug mode once we connect to the AP server.
-- The REPL Powershell window is orphaned once you close the game - you will have to kill it manually when you stop playing.
-- The powershell windows cannot be run as background processes due to how the REPL works, so the best we can do is minimize them.
+- The REPL console window is orphaned once you close the game - you will have to kill it manually when you stop playing.
+- The console windows cannot be run as background processes due to how the REPL works, so the best we can do is minimize them.
 - Orbsanity checks may show up out of order in the text client.
 - Large item releases may take up to several minutes for the game to process them all. 


### PR DESCRIPTION
## What is this fixing or adding?
- Using a new messenger system in the mod that allows us to display up to 3 messages at a time (with a queue of 10 messages for chain-reactions and finished-game-releases.
- Removed the powershell requirements. We can run the game and the compiler apps directly. The game will log its output to a file to avoid issues with `stdout` flushing being stalled. This removes an entire window from the user's view, so it will be less cluttered, and it reduces our reliance on Windows.
- Updated more error messages to be more user-friendly.

## How was this tested?
Recorded some videos and screenshots of the process, posted on discord.

## If this makes graphical changes, please attach screenshots.
See discord.