### PR TITLE
Updated to add linux and potential MacOS support to launching gk and …

### DIFF
--- a/worlds/jakanddaxter/client.py
+++ b/worlds/jakanddaxter/client.py
@@ -596,10 +596,6 @@ async def run_game(ctx: JakAndDaxterContext):
             if Utils.is_windows:
                 goalc_process = subprocess.Popen(goalc_args, creationflags=subprocess.CREATE_NEW_CONSOLE)
             elif Utils.is_linux:
-                # This is to prevent issues with snap variants of GTK that fail to run with this flag set when trying to open goalc
-                if os.environ.get('GTK_PATH', None):
-                    del os.environ['GTK_PATH']
-                
                 # Here, program_launch is imported from archipelago to run executatbles, including terminal ones. 
                 goalc_process = program_launch(goalc_args, in_terminal=True)
             elif Utils.is_macos:

--- a/worlds/jakanddaxter/client.py
+++ b/worlds/jakanddaxter/client.py
@@ -14,6 +14,7 @@ from typing import Awaitable
 # Misc imports
 import colorama
 from PyMemoryEditor import OpenProcess, ProcessNotFoundError
+from psutil import NoSuchProcess
 
 # Archipelago imports
 import ModuleUpdate
@@ -330,10 +331,13 @@ class JakAndDaxterContext(CommonContext):
             await asyncio.sleep(0.1)
 
     async def run_memr_loop(self):
-        while True:
-            await self.memr.main_tick()
-            await asyncio.sleep(0.1)
-
+        try:
+            while True:
+                await self.memr.main_tick()
+                await asyncio.sleep(0.1)
+        # This catch re-engages the memr loop, enabling the client to re-connect on losing the process
+        except NoSuchProcess:
+            await self.run_memr_loop()
 
 def find_root_directory(ctx: JakAndDaxterContext):
 

--- a/worlds/jakanddaxter/client.py
+++ b/worlds/jakanddaxter/client.py
@@ -20,6 +20,7 @@ import ModuleUpdate
 import Utils
 
 from CommonClient import ClientCommandProcessor, CommonContext, server_loop, gui_enabled
+from Launcher import launch as program_launch
 from NetUtils import ClientStatus
 
 # Jak imports
@@ -591,55 +592,15 @@ async def run_game(ctx: JakAndDaxterContext):
             if Utils.is_windows:
                 goalc_process = subprocess.Popen(goalc_args, creationflags=subprocess.CREATE_NEW_CONSOLE)
             elif Utils.is_linux:
+                # This is to prevent issues with snap variants of GTK that fail to run with this flag set when trying to open goalc
                 if os.environ.get('GTK_PATH', None):
                     del os.environ['GTK_PATH']
                 
-                    
-                # Bash commands are wrapped in quotes, and so make a single argument for subprocess.Popen()
-                # 
-                # Here we are concatenating the args into a string, and if any of the args has a space, we
-                # wrap that arg in quotes before. This is to support filepaths with spaces in them
-                goalc_command = 'bash -c \''
-
-                for i, arg in enumerate(goalc_args):
-                    if i == 0:
-                        if ' ' in arg:
-                            goalc_command += f"\\'{arg}\\'"
-                        else:
-                            goalc_command += f"{arg}"
-                    else:
-                        if ' ' in arg:
-                            goalc_command += f" \\'{arg}\\'"
-                        else:
-                            goalc_command += f" {arg}"
-                
-                goalc_command += '\''
-                
-                logger.info(goalc_command)
-                
-                goalc_process = subprocess.Popen(['x-terminal-emulator', '-e', goalc_command])
+                # Here, program_launch is imported from archipelago to run executatbles, including terminal ones. 
+                goalc_process = program_launch(goalc_args, in_terminal=True)
             elif Utils.is_macos:
-                # osascript commands are wrapped in quotes, and so make a single argument for subprocess.Popen()
-                # 
-                # Here we are concatenating the args into a string, and if any of the args has a space, we
-                # wrap that arg in quotes before. This is to support filepaths with spaces in them
-                goalc_command = 'tell app "Terminal" to do script "'
-
-                for i, arg in enumerate(goalc_args):
-                    if i == 0:
-                        if ' ' in arg:
-                            goalc_command += f"\\'{arg}\\'"
-                        else:
-                            goalc_command += f"{arg}"
-                    else:
-                        if ' ' in arg:
-                            goalc_command += f" \\'{arg}\\'"
-                        else:
-                            goalc_command += f" {arg}"
-                
-                goalc_command += '"'
-                
-                goalc_process = subprocess.Popen(['osascript', '-e', goalc_command])
+                # Here, program_launch is imported from archipelago to run executatbles, including terminal ones. 
+                goalc_process = program_launch(goalc_args, in_terminal=True)
 
     except AttributeError as e:
         if " " in e.args[0]:


### PR DESCRIPTION
# JakAndDaxter: Adding Linux Support

## What is this fixing or adding?
Adding linux support and potential macos support by setting up terminals that open in new windows. If Utils.is_linux, then we check for gnome-terminal or konsole, and if Utils.is_macos, then we use 'open -a Terminal -n --args' then the regular command for goalc (OpenGOAL REPL/compiler)

## How was this tested?
Ran on my linux machine. Needs further testing on different distros

## If this makes graphical changes, please attach screenshots.
N/A