### PR TITLE
Jak1: Additional Advanced Movement

### DIFF
--- a/worlds/jakanddaxter/__init__.py
+++ b/worlds/jakanddaxter/__init__.py
@@ -130,17 +130,17 @@ class JakAndDaxterWebWorld(WebWorld):
             options.KlawwCliffClimb, # Easy when out of bounds spot is known
             options.KlawwBoulderSkip, # Same trick as above
             options.BoggySwampPreciseMovement, # Mostly just taking damage on some jumps to get to the next checkpoint
+            options.SnowyMountainEntranceClimb, # Jump onto the wall on the left and simply slide over
+            options.SnowyMountainFlutFlutEscape,
         ]),
         OptionGroup("Tricks & Glitches - Hard", [
             options.BoostedAndExtendedUppercuts,
             options.ForbiddenJungleAttacklessSpiralStumpsScoutFly, # Precise movement from temple to power cell
             options.MistyIslandAttacklessScoutFlies, # Some require relatively precise movement with long runback
-            options.BoggySwampFlutFlutEscape,
+            options.BoggySwampFlutFlutEscape, # Harder trick, long runback
             options.BoggySwampAttacklessAmbush, # Doing the lurker ambush without attacks is annoying (and hard)
             options.BoggySwampFlutFlutSkip, # Flut Flut course with only Roll Jump requires precise jumping
             options.LostPrecursorCitySingleJumpSlideTubeClimb, # Climbing the tube without attacks/moves is hard
-            options.SnowyMountainEntranceClimb,
-            options.SnowyMountainFlutFlutEscape,
         ]),
         OptionGroup("Traps", [
             options.FillerPowerCellsReplacedWithTraps,

--- a/worlds/jakanddaxter/__init__.py
+++ b/worlds/jakanddaxter/__init__.py
@@ -112,6 +112,36 @@ class JakAndDaxterWebWorld(WebWorld):
             options.CitizenOrbTradeAmount,
             options.OracleOrbTradeAmount,
         ]),
+        OptionGroup("Tricks & Glitches - Easy", [
+            options.AttackWithRollJump,  # Use Roll Jump instead of regular attacks to hit certain targets
+            options.AttacklessLurkerCannons, # Shoot the lurkers with their own cannon
+            options.SentinelBeachAttacklessPelican, # Shoot the Pelican with the cannon
+        ]),
+        OptionGroup("Tricks & Glitches - Medium", [
+            options.GeyserRockCliffClimb, # You have to know where to jump, but the jump is not terribly difficult
+            options.SandoverVillageCliffOrbCacheClimb, # Same here
+            options.SentinelBeachCannonTowerClimb, # Same here
+            options.ForbiddenJungleElevatorSkip, # Deload glitch is easy, but hitting the loading zone can be tricky
+            options.MistyIslandEarlyFarSideOrbCache, # Precise movement, but not too hard
+            options.MistyIslandArenaFightSkip, # Drop down from top or use cannon to shoot enemies
+            options.MistyIslandFarSideCliffSeesawSkip, # Relatively easy, but route is not obvious
+            options.RockVillageEarlyOrbCache, # Precise movement, but not too hard, fast retries possible
+            options.RockVillagePontoonSkip, # May require fast swimming, but not too tight
+            options.KlawwCliffClimb, # Easy when out of bounds spot is known
+            options.KlawwBoulderSkip, # Same trick as above
+            options.BoggySwampPreciseMovement, # Mostly just taking damage on some jumps to get to the next checkpoint
+        ]),
+        OptionGroup("Tricks & Glitches - Hard", [
+            options.BoostedAndExtendedUppercuts,
+            options.ForbiddenJungleAttacklessSpiralStumpsScoutFly, # Precise movement from temple to power cell
+            options.MistyIslandAttacklessScoutFlies, # Some require relatively precise movement with long runback
+            options.BoggySwampFlutFlutEscape,
+            options.BoggySwampAttacklessAmbush, # Doing the lurker ambush without attacks is annoying (and hard)
+            options.BoggySwampFlutFlutSkip, # Flut Flut course with only Roll Jump requires precise jumping
+            options.LostPrecursorCitySingleJumpSlideTubeClimb, # Climbing the tube without attacks/moves is hard
+            options.SnowyMountainEntranceClimb,
+            options.SnowyMountainFlutFlutEscape,
+        ]),
         OptionGroup("Traps", [
             options.FillerPowerCellsReplacedWithTraps,
             options.FillerOrbBundlesReplacedWithTraps,

--- a/worlds/jakanddaxter/options.py
+++ b/worlds/jakanddaxter/options.py
@@ -455,9 +455,82 @@ class MistyIslandArenaFightSkip(Toggle):
 
 
 class MistyIslandFarSideCliffSeesawSkip(Toggle):
-    """Create an alternative path to the far side cliff (with scout fly "Scout Fly On Ledge Near Arena Exit") in Misty
+    """
+    Create an alternative path to the far side cliff (with scout fly "Scout Fly On Ledge Near Arena Exit") in Misty
     Island. Enabling this setting may require Jak to use uneven terrain to reach the cliff with only Single Jump,
-    without using the seesaw. This only applies if "Enable Move Randomizer" is ON."""
+    without using the seesaw. This only applies if "Enable Move Randomizer" is ON.
+    """
+    display_name = "Misty Island Far Side Cliff Seesaw Skip"
+
+
+class RockVillageEarlyOrbCache(Toggle):
+    """
+    Create an alternative path to the orb cache in Rock Village. Enabling this setting may require Jak to use precise
+    movement to reach the orb cache with only Single Jump. This only applies if "Enable Move Randomizer" is ON.
+    """
+    display_name = "Rock Village Early Orb Cache"
+
+
+class RockVillagePontoonSkip(Toggle):
+    """
+    Create alternative paths to Boggy Swamp and Klaww Cliff in Rock Village. Enabling this setting may require Jak to
+    use precise movement to reach these locations without having the Warrior's Pontoons unlocked.
+    This only applies if "Enable Move Randomizer" is ON.
+    """
+    display_name = "Rock Village Pontoon Skip"
+
+
+class KlawwCliffClimb(Toggle):
+    """
+    Create an alternative path to get up to Klaww from Rock Village. Enabling this setting may require Jak to use
+    glitches and uneven terrain to reach Klaww with only Single Jump. This only applies if "Enable Move Randomizer" is
+    ON.
+    """
+    display_name = "Klaww Cliff Climb"
+
+
+class KlawwBoulderSkip(Toggle):
+    """
+    Create an alternative path to Klaww without meeting the power cell requirement. Enabling this setting may require
+    Jak to use glitches to each Klaww even if the boulder is not lifted. This may drastically increase the amount of
+    reachable locations when Rock Village is reachable. This only applies if "Enable Move Randomizer" is ON.
+    """
+    display_name = "Klaww Boulder Skip"
+
+
+class BoggySwampPreciseMovement(Toggle):
+    """
+    Create an alternative path through Boggy Swamp. Enabling this setting may require Jak to traverse through the
+    whole Boggy Swamp with only Single Jump using precise movement, invincibility after taking damage, and respawns.
+    This only applies if "Enable Move Randomizer" is ON.
+    """
+    display_name = "Boggy Swamp Precise Movement"
+
+
+class BoggySwampAttacklessAmbush(Toggle):
+    """
+    Create an alternative path through the boggy swamp ambush without attack moves. Enabling this setting may require
+    Jak to shoot yellow Eco through his goggles to defeat the ambush.
+    This only applies if "Enable Move Randomizer" is ON.
+    """
+    display_name = "Boggy Swamp Attackless Ambush"
+
+
+class BoggySwampFlutFlutSkip(Toggle):
+    """
+    Create an alternative path to the Flut Flut course. Enabling this setting may require Jak to complete the whole
+    Flut Flut course without Flut Flut, and only Roll and Roll Jump unlocked.
+    """
+    display_name = "Boggy Swamp Flut Flut Skip"
+
+
+class LostPrecursorCitySingleJumpSlideTubeClimb(Toggle):
+    """
+    Create an alternative path through the helix with the rising dark eco in Lost Precursor City. Enabling this setting
+    may require Jak to use precise movement to reach the power cell at the bottom of Lost Precursor City and escape the
+    rising dark eco with only Single Jump. This only applies if "Enable Move Randomizer" is ON.
+    """
+    display_name = "Lost Precursor City Single Jump Slide Tube Climb"
 
 
 class CompletionCondition(Choice):
@@ -507,5 +580,13 @@ class JakAndDaxterOptions(PerGameCommonOptions):
     misty_island_attackless_scout_flies: MistyIslandAttacklessScoutFlies
     misty_island_arena_fight_skip: MistyIslandArenaFightSkip
     misty_island_far_side_cliff_seesaw_skip: MistyIslandFarSideCliffSeesawSkip
+    rock_village_early_orb_cache: RockVillageEarlyOrbCache
+    rock_village_pontoon_skip: RockVillagePontoonSkip
+    klaww_cliff_climb: KlawwCliffClimb
+    klaww_boulder_skip: KlawwBoulderSkip
+    boggy_swamp_precise_movement: BoggySwampPreciseMovement
+    boggy_swamp_attackless_ambush: BoggySwampAttacklessAmbush
+    boggy_swamp_flut_flut_skip: BoggySwampFlutFlutSkip
+    lost_precursor_city_single_jump_slide_tube_climb: LostPrecursorCitySingleJumpSlideTubeClimb
     jak_completion_condition: CompletionCondition
     start_inventory_from_pool: StartInventoryPool

--- a/worlds/jakanddaxter/options.py
+++ b/worlds/jakanddaxter/options.py
@@ -368,6 +368,98 @@ class SnowyMountainFlutFlutEscape(Toggle):
     display_name = "Snowy Mountain Flut Flut Escape"
 
 
+class SandoverVillageCliffOrbCacheClimb(Toggle):
+    """
+    Create an alternative path to the Sandover Village orb cache on the cliff. Enabling this setting may require Jak to
+    use precise jumps to reach the orb cache (and the blue eco next to it) with only Single Jump.
+    This only applies if "Enable Move Randomizer" is ON.
+    """
+    display_name = "Sandover Village Orb Cache Climb"
+
+
+class AttacklessLurkerCannons(Toggle):
+    """
+    Create alternative paths to the lurker cannon power cells in Sentinel Beach and Misty Island. Enabling this setting
+    may require Jak to defeat the lurkers next to the cannon without any attacking moves.
+    This only applies if "Enable Move Randomizer" is ON.
+    """
+    display_name = "Attackless Lurker Cannons"
+
+
+class SentinelBeachAttacklessPelican(Toggle):
+    """
+    Create an alternative path to the Pelican power cell in Sentinel Beach. Enabling this setting may require Jak to
+    use obscure game mechanics to acquire the power cell without any attacking moves.
+    This only applies if "Enable Move Randomizer" is ON.
+    """
+    display_name = "Sentinel Beach Attackless Pelican"
+
+
+class AttackWithRollJump(Toggle):
+    """
+    Create alternative paths to some power cells which normally require attacking moves. Enabling this setting may
+    require Jak to use Roll Jump to acquire these power cells. This only applies if "Enable Move Randomizer" is ON.
+    """
+    display_name = "Attack with Roll Jump"
+
+
+class SentinelBeachGreenRidgeSkip(Toggle):
+    """
+    Create an alternative path to the ridge near the green vents in Sentinel Beach. Enabling this setting may require
+    Jak to collect the scout fly and orbs on the ridge without having moves unlocked to get up the ridge.
+    This only applies if "Enable Move Randomizer" is ON.
+    """
+    display_name = "Sentinel Beach Green Ridge Skip"
+
+
+class ForbiddenJungleAttacklessSpiralStumpsScoutFly(Toggle):
+    """
+    Create an alternative path to the Scout Fly On Spiral Of Stumps in Forbidden Jungle. Enabling this setting may
+    require Jak to collect this scout fly without attack moves. This only applies if "Enable Move Randomizer" is ON.
+    """
+    display_name = "Forbidden Jungle Attackless Spiral Stumps Scout Fly"
+
+
+class ForbiddenJungleElevatorSkip(Toggle):
+    """
+    Create an alternative path to the temple interior in Forbidden Jungle. Enabling this setting may require Jak to
+    get inside the temple without having the Jungle Elevator unlocked.
+    """
+    display_name = "Forbidden Jungle Elevator Skip"
+
+
+class MistyIslandEarlyFarSideOrbCache(Toggle):
+    """
+    Create an alternative path to the Far Side Orb Cache in Misty Island. Enabling this setting may require Jak to
+    reach the orb cache with blue eco with only Single Jump. This only applies if "Enable Move Randomizer" is ON.
+    """
+    display_name = "Misty Island Early Far Side Orb Cache"
+
+
+class MistyIslandAttacklessScoutFlies(Toggle):
+    """
+    Create alternative paths to the scout flies "Barrel Ramps", "Ledge Near Arena Entrance", "Near Arena Door",
+    "Overlooking Entrance" in Misty Island. Enabling this setting may require Jak to break these scout fly boxes with
+    precise blue eco movement or clever use of game mechanics.
+    This only applies if "Enable Move Randomizer" is ON.
+    """
+    display_name = "Misty Island Attackless Barrel Course Scout Fly"
+
+
+class MistyIslandArenaFightSkip(Toggle):
+    """
+    Create an alternative path to the power cell "Return To The Dark Eco Pool" in Misty Island. Enabling this setting
+    may require Jak to reach this power cell with only Single Jump. This only applies if "Enable Move Randomizer" is ON.
+    """
+    display_name = "Misty Island Arena Fight Skip"
+
+
+class MistyIslandFarSideCliffSeesawSkip(Toggle):
+    """Create an alternative path to the far side cliff (with scout fly "Scout Fly On Ledge Near Arena Exit") in Misty
+    Island. Enabling this setting may require Jak to use uneven terrain to reach the cliff with only Single Jump,
+    without using the seesaw. This only applies if "Enable Move Randomizer" is ON."""
+
+
 class CompletionCondition(Choice):
     """Set the goal for completing the game."""
     display_name = "Completion Condition"
@@ -404,5 +496,16 @@ class JakAndDaxterOptions(PerGameCommonOptions):
     snowy_mountain_entrance_climb: SnowyMountainEntranceClimb
     boggy_swamp_flut_flut_escape: BoggySwampFlutFlutEscape
     snowy_mountain_flut_flut_escape: SnowyMountainFlutFlutEscape
+    sandover_village_cliff_orb_cache_climb: SandoverVillageCliffOrbCacheClimb
+    attackless_lurker_cannons: AttacklessLurkerCannons
+    sentinel_beach_attackless_pelican: SentinelBeachAttacklessPelican
+    attack_with_roll_jump: AttackWithRollJump
+    sentinel_beach_green_ridge_skip: SentinelBeachGreenRidgeSkip
+    forbidden_jungle_attackless_spiral_stumps_scout_fly: ForbiddenJungleAttacklessSpiralStumpsScoutFly
+    forbidden_jungle_elevator_skip: ForbiddenJungleElevatorSkip
+    misty_island_early_far_side_orb_cache: MistyIslandEarlyFarSideOrbCache
+    misty_island_attackless_scout_flies: MistyIslandAttacklessScoutFlies
+    misty_island_arena_fight_skip: MistyIslandArenaFightSkip
+    misty_island_far_side_cliff_seesaw_skip: MistyIslandFarSideCliffSeesawSkip
     jak_completion_condition: CompletionCondition
     start_inventory_from_pool: StartInventoryPool

--- a/worlds/jakanddaxter/options.py
+++ b/worlds/jakanddaxter/options.py
@@ -414,7 +414,7 @@ class ForbiddenJungleAttacklessSpiralStumpsScoutFly(Toggle):
 class ForbiddenJungleElevatorSkip(Toggle):
     """
     Create an alternative path to the temple interior in Forbidden Jungle. Enabling this setting may require Jak to
-    get inside the temple without having the Jungle Elevator unlocked.
+    get inside the temple with only Jump Kick (without having the Jungle Elevator unlocked).
     """
     display_name = "Forbidden Jungle Elevator Skip"
 
@@ -434,7 +434,7 @@ class MistyIslandAttacklessScoutFlies(Toggle):
     precise blue eco movement or clever use of game mechanics.
     This only applies if "Enable Move Randomizer" is ON.
     """
-    display_name = "Misty Island Attackless Barrel Course Scout Fly"
+    display_name = "Misty Island Attackless Scout Flies"
 
 
 class MistyIslandArenaFightSkip(Toggle):

--- a/worlds/jakanddaxter/options.py
+++ b/worlds/jakanddaxter/options.py
@@ -379,8 +379,8 @@ class SandoverVillageCliffOrbCacheClimb(Toggle):
 
 class AttacklessLurkerCannons(Toggle):
     """
-    Create alternative paths to the lurker cannon power cells in Sentinel Beach and Misty Island. Enabling this setting
-    may require Jak to defeat the lurkers next to the cannon without any attacking moves.
+    Remove the attack requirement for lurker cannon power cells in Sentinel Beach and Misty Island. Enabling this
+    setting may require Jak to defeat the lurkers next to the cannon without any attacking moves.
     This only applies if "Enable Move Randomizer" is ON.
     """
     display_name = "Attackless Lurker Cannons"
@@ -389,7 +389,7 @@ class AttacklessLurkerCannons(Toggle):
 class SentinelBeachAttacklessPelican(Toggle):
     """
     Create an alternative path to the Pelican power cell in Sentinel Beach. Enabling this setting may require Jak to
-    use obscure game mechanics to acquire the power cell without any attacking moves.
+    use other unlocks to acquire the power cell without any attacking moves.
     This only applies if "Enable Move Randomizer" is ON.
     """
     display_name = "Sentinel Beach Attackless Pelican"
@@ -397,24 +397,15 @@ class SentinelBeachAttacklessPelican(Toggle):
 
 class AttackWithRollJump(Toggle):
     """
-    Create alternative paths to some power cells which normally require attacking moves. Enabling this setting may
-    require Jak to use Roll Jump to acquire these power cells. This only applies if "Enable Move Randomizer" is ON.
+    Treat Roll Jump as a valid attack move for some power cells. Enabling this setting may require Jak to use Roll Jump
+    to destroy objects to acquire these power cells. This only applies if "Enable Move Randomizer" is ON.
     """
     display_name = "Attack with Roll Jump"
 
 
-class SentinelBeachGreenRidgeSkip(Toggle):
-    """
-    Create an alternative path to the ridge near the green vents in Sentinel Beach. Enabling this setting may require
-    Jak to collect the scout fly and orbs on the ridge without having moves unlocked to get up the ridge.
-    This only applies if "Enable Move Randomizer" is ON.
-    """
-    display_name = "Sentinel Beach Green Ridge Skip"
-
-
 class ForbiddenJungleAttacklessSpiralStumpsScoutFly(Toggle):
     """
-    Create an alternative path to the Scout Fly On Spiral Of Stumps in Forbidden Jungle. Enabling this setting may
+    Create an alternative path to the Scout Fly "On Spiral Of Stumps" in Forbidden Jungle. Enabling this setting may
     require Jak to collect this scout fly without attack moves. This only applies if "Enable Move Randomizer" is ON.
     """
     display_name = "Forbidden Jungle Attackless Spiral Stumps Scout Fly"
@@ -438,7 +429,7 @@ class MistyIslandEarlyFarSideOrbCache(Toggle):
 
 class MistyIslandAttacklessScoutFlies(Toggle):
     """
-    Create alternative paths to the scout flies "Barrel Ramps", "Ledge Near Arena Entrance", "Near Arena Door",
+    Remove attack requirements to the scout flies "Barrel Ramps", "Ledge Near Arena Entrance", "Near Arena Door",
     "Overlooking Entrance" in Misty Island. Enabling this setting may require Jak to break these scout fly boxes with
     precise blue eco movement or clever use of game mechanics.
     This only applies if "Enable Move Randomizer" is ON.
@@ -457,15 +448,15 @@ class MistyIslandArenaFightSkip(Toggle):
 class MistyIslandFarSideCliffSeesawSkip(Toggle):
     """
     Create an alternative path to the far side cliff (with scout fly "Scout Fly On Ledge Near Arena Exit") in Misty
-    Island. Enabling this setting may require Jak to use uneven terrain to reach the cliff with only Single Jump,
-    without using the seesaw. This only applies if "Enable Move Randomizer" is ON.
+    Island. Enabling this setting may require Jak to use uneven terrain to find an alternative way to the cliff, using
+    only Single Jump. This only applies if "Enable Move Randomizer" is ON.
     """
     display_name = "Misty Island Far Side Cliff Seesaw Skip"
 
 
 class RockVillageEarlyOrbCache(Toggle):
     """
-    Create an alternative path to the orb cache in Rock Village. Enabling this setting may require Jak to use precise
+    Remove requirements from the orb cache in Rock Village. Enabling this setting may require Jak to use precise
     movement to reach the orb cache with only Single Jump. This only applies if "Enable Move Randomizer" is ON.
     """
     display_name = "Rock Village Early Orb Cache"
@@ -491,8 +482,8 @@ class KlawwCliffClimb(Toggle):
 
 class KlawwBoulderSkip(Toggle):
     """
-    Create an alternative path to Klaww without meeting the power cell requirement. Enabling this setting may require
-    Jak to use glitches to each Klaww even if the boulder is not lifted. This may drastically increase the amount of
+    Create an alternative path to Klaww without having enough power cells. Enabling this setting may require
+    Jak to use glitches to reach Klaww even if the boulder is not lifted. This may drastically increase the amount of
     reachable locations when Rock Village is reachable. This only applies if "Enable Move Randomizer" is ON.
     """
     display_name = "Klaww Boulder Skip"
@@ -509,17 +500,16 @@ class BoggySwampPreciseMovement(Toggle):
 
 class BoggySwampAttacklessAmbush(Toggle):
     """
-    Create an alternative path through the boggy swamp ambush without attack moves. Enabling this setting may require
-    Jak to shoot yellow Eco through his goggles to defeat the ambush.
-    This only applies if "Enable Move Randomizer" is ON.
+    Remove the attack requirement from the Boggy Swamp ambush. Enabling this setting may require Jak to shoot yellow Eco
+    through his goggles to defeat the lurkers. This only applies if "Enable Move Randomizer" is ON.
     """
     display_name = "Boggy Swamp Attackless Ambush"
 
 
 class BoggySwampFlutFlutSkip(Toggle):
     """
-    Create an alternative path to the Flut Flut course. Enabling this setting may require Jak to complete the whole
-    Flut Flut course without Flut Flut, and only Roll and Roll Jump unlocked.
+    Create an alternative path to the Flut Flut course without having Flut Flut unlocked. Enabling this setting may
+    require Jak to complete the whole course with only Roll and Roll Jump.
     """
     display_name = "Boggy Swamp Flut Flut Skip"
 
@@ -573,7 +563,6 @@ class JakAndDaxterOptions(PerGameCommonOptions):
     attackless_lurker_cannons: AttacklessLurkerCannons
     sentinel_beach_attackless_pelican: SentinelBeachAttacklessPelican
     attack_with_roll_jump: AttackWithRollJump
-    sentinel_beach_green_ridge_skip: SentinelBeachGreenRidgeSkip
     forbidden_jungle_attackless_spiral_stumps_scout_fly: ForbiddenJungleAttacklessSpiralStumpsScoutFly
     forbidden_jungle_elevator_skip: ForbiddenJungleElevatorSkip
     misty_island_early_far_side_orb_cache: MistyIslandEarlyFarSideOrbCache

--- a/worlds/jakanddaxter/regions.py
+++ b/worlds/jakanddaxter/regions.py
@@ -103,7 +103,11 @@ def create_regions(world: "JakAndDaxterWorld"):
     rv.connect(pb)
     rv.connect(lpc)
     rvp.connect(bs)  # rv->rvp/rvc connections defined internally by RockVillageRegions.
-    rvc.connect(mp, rule=lambda state: state.has("Power Cell", player, mp_count))  # Normally 45.
+    if options.klaww_boulder_skip:
+        # With Klaww boulder skip, it is always possible to reach Mountain Pass without any power cell requirements.
+        rvc.connect(mp)
+    else:
+        rvc.connect(mp, rule=lambda state: state.has("Power Cell", player, mp_count))  # Normally 45.
     mpr.connect(vc)  # mp->mpr connection defined internally by MountainPassRegions.
     vc.connect(sc)
     vc.connect(sm, rule=lambda state: state.has("Snowy Mountain Gondola", player))

--- a/worlds/jakanddaxter/regs/forbidden_jungle_regions.py
+++ b/worlds/jakanddaxter/regs/forbidden_jungle_regions.py
@@ -45,7 +45,7 @@ def build_regions(level_name: str, world: "JakAndDaxterWorld") -> tuple[JakAndDa
     temple_exit = JakAndDaxterRegion("Temple Exit", player, multiworld, level_name, 12)
 
     if options.forbidden_jungle_attackless_spiral_stumps_scout_fly:
-        # This fly can be reached using the blue eco vent inside the temple, (easiest with Fall Damage Animation Cancel)
+        # This fly can be reached using the blue eco vent inside the temple (easiest with Fall Damage Animation Cancel).
         temple_exit.add_fly_locations([262151])
     else:
         # This fly is too far from accessible blue eco sources.

--- a/worlds/jakanddaxter/regs/forbidden_jungle_regions.py
+++ b/worlds/jakanddaxter/regs/forbidden_jungle_regions.py
@@ -1,3 +1,4 @@
+from BaseClasses import CollectionState
 from .region_base import JakAndDaxterRegion
 from ..options import EnableOrbsanity
 from typing import TYPE_CHECKING
@@ -11,6 +12,15 @@ def build_regions(level_name: str, world: "JakAndDaxterWorld") -> tuple[JakAndDa
     options = world.options
     player = world.player
 
+    # Define a helper function for all locations that can be acquired by regular fight moves or roll jump
+    # We do not want to check the options each time we call those functions for performance reasons
+    if options.attack_with_roll_jump:
+        def can_fight_or_roll_jump(state: CollectionState, p: int) -> bool:
+            return can_fight(state, p) or state.has_all(("Roll", "Roll Jump"), p)
+    else:
+        def can_fight_or_roll_jump(state: CollectionState, p: int) -> bool:
+            return can_fight(state, p)
+
     main_area = JakAndDaxterRegion("Main Area", player, multiworld, level_name, 25)
 
     # You can get this scout fly by running from the blue eco vent across the temple bridge,
@@ -18,7 +28,7 @@ def build_regions(level_name: str, world: "JakAndDaxterWorld") -> tuple[JakAndDa
     main_area.add_fly_locations([393223])
 
     lurker_machine = JakAndDaxterRegion("Lurker Machine", player, multiworld, level_name, 5)
-    lurker_machine.add_cell_locations([3], access_rule=lambda state: can_fight(state, player))
+    lurker_machine.add_cell_locations([3], access_rule=lambda state: can_fight_or_roll_jump(state, player))
 
     # This cell and this scout fly can both be gotten with the blue eco clusters near the jump pad.
     lurker_machine.add_cell_locations([9])
@@ -34,8 +44,12 @@ def build_regions(level_name: str, world: "JakAndDaxterWorld") -> tuple[JakAndDa
 
     temple_exit = JakAndDaxterRegion("Temple Exit", player, multiworld, level_name, 12)
 
-    # This fly is too far from accessible blue eco sources.
-    temple_exit.add_fly_locations([262151], access_rule=lambda state: can_free_scout_flies(state, player))
+    if options.forbidden_jungle_attackless_spiral_stumps_scout_fly:
+        # This fly can be reached using the blue eco vent inside the temple, (easiest with Fall Damage Animation Cancel)
+        temple_exit.add_fly_locations([262151])
+    else:
+        # This fly is too far from accessible blue eco sources.
+        temple_exit.add_fly_locations([262151], access_rule=lambda state: can_free_scout_flies(state, player))
 
     temple_exterior = JakAndDaxterRegion("Temple Exterior", player, multiworld, level_name, 10)
 
@@ -68,8 +82,14 @@ def build_regions(level_name: str, world: "JakAndDaxterWorld") -> tuple[JakAndDa
     temple_exit.connect(river)                      # Jump down.
     temple_exit.connect(temple_exterior)            # Run and jump (bridges, dodge spikes).
 
-    # Requires Jungle Elevator.
-    temple_exterior.connect(temple_int_pre_blue, rule=lambda state: state.has("Jungle Elevator", player))
+    if options.forbidden_jungle_elevator_skip:
+        # With a deload, it's possible to skip the Elevator, but Jak has to hit the loading zone while falling down.
+        # With Jump Kick, that's definitely possible.
+        temple_exterior.connect(temple_int_pre_blue, rule=lambda state:
+                                state.has("Jungle Elevator", player) or state.has("Jump Kick", player))
+    else:
+        # Requires Jungle Elevator.
+        temple_exterior.connect(temple_int_pre_blue, rule=lambda state: state.has("Jungle Elevator", player))
 
     # Requires Blue Eco Switch.
     temple_int_pre_blue.connect(temple_int_post_blue, rule=lambda state: state.has("Blue Eco Switch", player))

--- a/worlds/jakanddaxter/regs/lost_precursor_city_regions.py
+++ b/worlds/jakanddaxter/regs/lost_precursor_city_regions.py
@@ -47,7 +47,7 @@ def build_regions(level_name: str, world: "JakAndDaxterWorld") -> JakAndDaxterRe
     center_complex.add_cell_locations([51])
 
     color_platforms = JakAndDaxterRegion("Color Platforms", player, multiworld, level_name, 6)
-    # This power cell can be reached with only a Single Jump by taking damage once to start the left platform.
+    # This power cell can be reached with only a Single Jump by taking damage once to start at the left platform.
     color_platforms.add_cell_locations([44])
 
     quick_platforms = JakAndDaxterRegion("Quick Platforms", player, multiworld, level_name, 3)

--- a/worlds/jakanddaxter/regs/misty_island_regions.py
+++ b/worlds/jakanddaxter/regs/misty_island_regions.py
@@ -15,7 +15,11 @@ def build_regions(level_name: str, world: "JakAndDaxterWorld") -> JakAndDaxterRe
 
     muse_course = JakAndDaxterRegion("Muse Course", player, multiworld, level_name, 21)
     muse_course.add_cell_locations([23])
-    muse_course.add_fly_locations([327708], access_rule=lambda state: can_free_scout_flies(state, player))
+    if options.misty_island_attackless_scout_flies:
+        # Grabbing 3 blue eco orbs and running back can reach this scout fly
+        muse_course.add_fly_locations([327708])
+    else:
+        muse_course.add_fly_locations([327708], access_rule=lambda state: can_free_scout_flies(state, player))
 
     zoomer = JakAndDaxterRegion("Zoomer", player, multiworld, level_name, 32)
     zoomer.add_cell_locations([27, 29])
@@ -33,24 +37,44 @@ def build_regions(level_name: str, world: "JakAndDaxterWorld") -> JakAndDaxterRe
 
     # To carry the blue eco fast enough to open this cache, you need to break the bone bridges along the way.
     far_side_cache = JakAndDaxterRegion("Far Side Orb Cache", player, multiworld, level_name, 15)
-    far_side_cache.add_cache_locations([11072], access_rule=lambda state: can_fight(state, player))
+    if options.misty_island_early_far_side_orb_cache:
+        # It's possible to reach the orb cache without any attacks.
+        far_side_cache.add_cache_locations([11072])
+    else:
+        far_side_cache.add_cache_locations([11072], access_rule=lambda state: can_fight(state, player))
 
     barrel_course = JakAndDaxterRegion("Barrel Course", player, multiworld, level_name, 10)
-    barrel_course.add_fly_locations([196636], access_rule=lambda state: can_free_scout_flies(state, player))
+    if options.misty_island_attackless_scout_flies:
+        # It's possible to break the scout fly by running into the explosive box next to it.
+        barrel_course.add_fly_locations([196636])
+    else:
+        barrel_course.add_fly_locations([196636], access_rule=lambda state: can_free_scout_flies(state, player))
 
     # 14 orbs for the boxes you can only break with the cannon.
     cannon = JakAndDaxterRegion("Cannon", player, multiworld, level_name, 14)
-    cannon.add_cell_locations([26], access_rule=lambda state: can_fight(state, player))
+    if options.attackless_lurker_cannons:
+        # It's possible to hit the lurker with the cannon without having an attack move.
+        cannon.add_cell_locations([26])
+    else:
+        cannon.add_cell_locations([26], access_rule=lambda state: can_fight(state, player))
 
     upper_approach = JakAndDaxterRegion("Upper Arena Approach", player, multiworld, level_name, 6)
-    upper_approach.add_fly_locations([65564, 262172], access_rule=lambda state:
-                                     can_free_scout_flies(state, player))
+    if options.misty_island_attackless_scout_flies:
+        # These can be reached with blue eco.
+        upper_approach.add_fly_locations([65564, 262172])
+    else:
+        upper_approach.add_fly_locations([65564, 262172], access_rule=lambda state:
+                                         can_free_scout_flies(state, player))
 
     lower_approach = JakAndDaxterRegion("Lower Arena Approach", player, multiworld, level_name, 7)
     lower_approach.add_cell_locations([30])
 
     arena = JakAndDaxterRegion("Arena", player, multiworld, level_name, 5)
-    arena.add_cell_locations([25], access_rule=lambda state: can_fight(state, player))
+    if options.misty_island_arena_fight_skip:
+        # This can be reached by letting the cannon defeat the enemies, or by dropping down from the cannon platform.
+        arena.add_cell_locations([25])
+    else:
+        arena.add_cell_locations([25], access_rule=lambda state: can_fight(state, player))
 
     main_area.connect(muse_course)             # TODO - What do you need to chase the muse the whole way around?
     main_area.connect(zoomer)                  # Run and jump down.
@@ -87,6 +111,11 @@ def build_regions(level_name: str, world: "JakAndDaxterWorld") -> JakAndDaxterRe
     cannon.connect(barrel_course)              # Run and jump (dodge barrels).
     cannon.connect(arena)                      # Run and jump down.
     cannon.connect(upper_approach)             # Run and jump down.
+
+    if options.misty_island_far_side_cliff_seesaw_skip:
+        # It's possible to reach the far side cliff by jumping onto the rock behind the cannon, getting close enough
+        # and then carefully sliding down to the cliff.
+        cannon.connect(far_side_cliff)
 
     upper_approach.connect(lower_approach)     # Jump down.
     upper_approach.connect(arena)              # Jump down.

--- a/worlds/jakanddaxter/regs/misty_island_regions.py
+++ b/worlds/jakanddaxter/regs/misty_island_regions.py
@@ -16,7 +16,7 @@ def build_regions(level_name: str, world: "JakAndDaxterWorld") -> JakAndDaxterRe
     muse_course = JakAndDaxterRegion("Muse Course", player, multiworld, level_name, 21)
     muse_course.add_cell_locations([23])
     if options.misty_island_attackless_scout_flies:
-        # Grabbing 3 blue eco orbs and running back can reach this scout fly
+        # Grabbing blue eco orbs and running back can reach this scout fly
         muse_course.add_fly_locations([327708])
     else:
         muse_course.add_fly_locations([327708], access_rule=lambda state: can_free_scout_flies(state, player))

--- a/worlds/jakanddaxter/regs/rock_village_regions.py
+++ b/worlds/jakanddaxter/regs/rock_village_regions.py
@@ -45,7 +45,11 @@ def build_regions(level_name: str, world: "JakAndDaxterWorld") -> tuple[JakAndDa
 
     klaww_cliff = JakAndDaxterRegion("Klaww's Cliff", player, multiworld, level_name, 0)
 
-    main_area.connect(orb_cache, rule=lambda state: state.has_all(("Roll", "Roll Jump"), player))
+    if options.rock_village_early_orb_cache:
+        # It is possible to just reach the orb cache with blue eco without roll jump.
+        main_area.connect(orb_cache)
+    else:
+        main_area.connect(orb_cache, rule=lambda state: state.has_all(("Roll", "Roll Jump"), player))
 
     if options.rock_village_pontoon_skip:
         # Reachable with Jump/Swim

--- a/worlds/jakanddaxter/regs/sandover_village_regions.py
+++ b/worlds/jakanddaxter/regs/sandover_village_regions.py
@@ -22,7 +22,7 @@ def build_regions(level_name: str, world: "JakAndDaxterWorld") -> JakAndDaxterRe
     main_area.add_fly_locations([262219, 327755, 131147, 65611])
 
     if options.sandover_village_cliff_orb_cache_climb:
-        # It is possible to jump up to the blue Eco next to the Orb Cache, and take it to the Farmer's scout fly
+        # It is possible to jump up to the blue Eco next to the Orb Cache, and take it to the Farmer's scout fly.
         main_area.add_fly_locations([196683])
     else:
         # The farmer's scout fly. You can either get the Orb Cache Cliff blue eco, or break it normally.

--- a/worlds/jakanddaxter/regs/sandover_village_regions.py
+++ b/worlds/jakanddaxter/regs/sandover_village_regions.py
@@ -21,11 +21,15 @@ def build_regions(level_name: str, world: "JakAndDaxterWorld") -> JakAndDaxterRe
     # These 4 scout fly boxes can be broken by running with all the blue eco from Sentinel Beach.
     main_area.add_fly_locations([262219, 327755, 131147, 65611])
 
-    # The farmer's scout fly. You can either get the Orb Cache Cliff blue eco, or break it normally.
-    main_area.add_fly_locations([196683], access_rule=lambda state:
-                                state.has("Double Jump", player)
-                                or state.has_all(("Crouch", "Crouch Jump"), player)
-                                or can_free_scout_flies(state, player))
+    if options.sandover_village_cliff_orb_cache_climb:
+        # It is possible to jump up to the blue Eco next to the Orb Cache, and take it to the Farmer's scout fly
+        main_area.add_fly_locations([196683])
+    else:
+        # The farmer's scout fly. You can either get the Orb Cache Cliff blue eco, or break it normally.
+        main_area.add_fly_locations([196683], access_rule=lambda state:
+                                    state.has("Double Jump", player)
+                                    or state.has_all(("Crouch", "Crouch Jump"), player)
+                                    or can_free_scout_flies(state, player))
 
     orb_cache_cliff = JakAndDaxterRegion("Orb Cache Cliff", player, multiworld, level_name, 15)
     orb_cache_cliff.add_cache_locations([10344])
@@ -41,10 +45,14 @@ def build_regions(level_name: str, world: "JakAndDaxterWorld") -> JakAndDaxterRe
     oracle_platforms.add_fly_locations([393291], access_rule=lambda state:
                                        can_free_scout_flies(state, player))
 
-    main_area.connect(orb_cache_cliff, rule=lambda state:
-                      state.has("Double Jump", player)
-                      or state.has_all(("Crouch", "Crouch Jump"), player)
-                      or state.has_all(("Crouch", "Crouch Uppercut", "Jump Kick"), player))
+    if options.sandover_village_cliff_orb_cache_climb:
+        # It is possible to reach this cliff (and the blue Eco next to it) with a single jump
+        main_area.connect(orb_cache_cliff)
+    else:
+        main_area.connect(orb_cache_cliff, rule=lambda state:
+                          state.has("Double Jump", player)
+                          or state.has_all(("Crouch", "Crouch Jump"), player)
+                          or state.has_all(("Crouch", "Crouch Uppercut", "Jump Kick"), player))
 
     main_area.connect(yakow_cliff, rule=lambda state:
                       state.has("Double Jump", player)

--- a/worlds/jakanddaxter/regs/sentinel_beach_regions.py
+++ b/worlds/jakanddaxter/regs/sentinel_beach_regions.py
@@ -62,12 +62,7 @@ def build_regions(level_name: str, world: "JakAndDaxterWorld") -> JakAndDaxterRe
     eco_harvesters.add_cell_locations([15], access_rule=lambda state: can_fight_or_roll_jump(state, player))
 
     green_ridge = JakAndDaxterRegion("Ridge Near Green Vents", player, multiworld, level_name, 5)
-    if options.sentinel_beach_green_ridge_skip:
-        # You can bring the blue eco from the switch all the way over here
-        green_ridge.add_fly_locations([131092], access_rule=lambda state:
-                                      state.has("Blue Eco Switch", player) or can_free_scout_flies(state, player))
-    else:
-        green_ridge.add_fly_locations([131092], access_rule=lambda state: can_free_scout_flies(state, player))
+    green_ridge.add_fly_locations([131092], access_rule=lambda state: can_free_scout_flies(state, player))
 
     blue_ridge = JakAndDaxterRegion("Ridge Near Blue Vent", player, multiworld, level_name, 5)
     blue_ridge.add_fly_locations([196628], access_rule=lambda state:
@@ -93,19 +88,11 @@ def build_regions(level_name: str, world: "JakAndDaxterWorld") -> JakAndDaxterRe
                 and (state.has_all(("Crouch", "Crouch Uppercut"), p)
                      or state.has_all(("Punch", "Punch Uppercut"), p)))
 
-    if options.sentinel_beach_green_ridge_skip:
-        # You can collect everything on the green ridge with blue eco, even if you cannot get up
-        main_area.connect(green_ridge, rule=lambda state:
-                          state.has("Double Jump", player)
-                          or state.has_all(("Crouch", "Crouch Jump"), player)
-                          or can_uppercut_and_jump_logs(state, player)
-                          or state.has("Blue Eco Switch", player))
-    else:
-        # If you have double jump or crouch jump, you don't need the logs to reach this place.
-        main_area.connect(green_ridge, rule=lambda state:
-                          state.has("Double Jump", player)
-                          or state.has_all(("Crouch", "Crouch Jump"), player)
-                          or can_uppercut_and_jump_logs(state, player))
+    # If you have double jump or crouch jump, you don't need the logs to reach this place.
+    main_area.connect(green_ridge, rule=lambda state:
+                      state.has("Double Jump", player)
+                      or state.has_all(("Crouch", "Crouch Jump"), player)
+                      or can_uppercut_and_jump_logs(state, player))
 
     # If you have the blue eco jump pad, you don't need the logs to reach this place.
     main_area.connect(blue_ridge, rule=lambda state:


### PR DESCRIPTION
As discussed in the Discord, I've added a few additional options that change the logic to allow certain skips, tricks, and glitches to reach locations earlier than intended. This PR adds additional logic to all areas around hub 1 + hub 2.

## Additional Changes

I've changed some additional things that I'll list here separately. Depending on your feedback I can obviously change everything.

### LPC Logic Change: Color Platforms

I've removed the "can_fight" requirement to the power cell "LPC: Match The Platform Colors". You just have to jump on all platforms to get the power cell, no fighting required. There is a flying enemy who can be defeated (but you don't have to) - and the enemy is not more annoying than other enemies for stuff that's in-logic without attack moves. If there is a specific reason to require fighting here that I don't see, then please tell me and I can add it back.

### Option Groups

I've added three new option groups: Tricks & Glitches - Easy, Medium, and Hard. I've put the options into these groups depending on the execution difficulty (and generally not "knowledge difficulty"). The intention is to give players some guidance on how large the impact to their run may be. I've tried to roughly categorize them like this:

* **Easy**: Tricks that you generally cannot fail if you know them. Players could always enable these options, look up the tricks if they get stuck, and finish any run.
* **Medium**: Tricks that I can generally do in max. 5-10 minutes. Players that enable these options can look up the tricks if they get stuck, and learn+execute them once in max. 30 minutes.
* **Hard**: Tricks that may increase the run duration a lot if you didn't know about them and have to learn them during the run.

The categorization is obviously subjective, and I can also put everything into one group if you would prefer this - but I personally think it's nice to have some categories to easily distinguish "shoot the pelican with the cannon" and "climb the LPC tube with only a single jump". I've added your tricks (BS Flut Flut Escape, SM Entrance Climb, SM Flut Flut Escape Boosted/Extended Uppercuts) to the "Hard" category as I haven't looked them up/tried them out yet (except for "Tower Climb" which I put into "Medium").

### Boggy Swamp

The current BS logic is very generous and requires Jak to have any high jump + far jump move unlocked to get nearly anything. There are a lot of places you can reach with only a single jump, by cleverly taking some unavoidable damage to reach the next checkpoint. I've put all these logic changes behind a single "BS Precise Movement" option, because otherwise there would be multiple options that all use the exact same trick/behavior. Currently, the following is included in this option (please tell me if you want to have something split up more):

* Go to the first bats from the main area (Single Jump into the dark pool to take damage once)
* Get the "Scout Fly Across Black Swamp" (Single Jump into the dark pool to take damage once, directly next to the checkpoint, very easy)
* Jump up from Farthy Snacks to go towards the box field (Single Jump can reach the ledge when positioned correctly, not very hard)
* Continue on from Box Field to the end of BS (Same "taking unavoidable damage" strategy - a bit harder, but there is usually a big green eco blob in the box field, and it's also possible - but hard - to reach the checkpoint by taking damage only 2 times)
* Grab the 4th tether power cell (and orbs) by using the shroom platforms (generally easy, getting the orb can be a bit tricky, but can be retried immediately)
* Grab the orbs on the first tether rat colony by leaving them rat colony alive. This feels the most like it should be separate - but it's only for 3 orbs, and adding an option just to grab 3 additional orbs seemed a bit silly. It's also possible to retry this after respawning at the checkpoint.
* Add Jump Kick as a movement option to get the 2nd tether power cell

### Klaww Skip

I've added two options for Klaww Skip: "Cliff Climb" and "Boulder Skip". Both can be done with the same out-of-bounds trick, but "Boulder Skip" removes the power cell requirement to reach Klaww (once you can reach the rock, either because "Cliff Climb" is enabled or the relevant move options are unlocked). This unlocks a lot of locations once the player can go through Fire Canyon which makes progression balancing less effective (because the area is so large and Archipelago doesn't care what's "physically closer" as far as I know).

### Option Description

I've tried to keep the option descriptions intentionally vague so I won't give away the solution but tried to still include enough detail so that players know which skills they may need. In the code comments, I've tried to always add a (short) explanation on how to actually do the trick.

If you would prefer a different option description style (or different names for options), then please just tell me and I'll adapt it.

## Testing

I've tested everything in a separate branch that's up-to-date with the master branch (I got some weird Python issues when executing this branch directly, and didn't look into it since I have a working setup for the newest Archipelago version).

* All Unit Tests passed (including github pipeline - but only on the newer branch)
* Fuzyy Test I've just done with parameters `fuzz.py -r 5000 -j 16 -g jakanddaxter -n 1-10` had 1 generation failure (but I've also had 5000-iteration-runs with no generation failures before)
* I've manually tested (nearly) every single trick I've added
  * I've not done "BoggySwampAttacklessAmbush" myself because it sounds miserable, but it is [possible](https://youtu.be/nxuF-N5g578?t=1245)
  * I've not done "LostPrecursorCitySingleJumpSlideTubeClimb" myself, but is is [possible](https://youtu.be/nxuF-N5g578?t=1043)
* I've done a full (single-player) run with a seed that unlocks moves relatively late, with all my new options and Orbsanity enabled. I've had Universal Tracker open during the run and verified that everything in-logic was possible, and that everything I did was actually in-logic.

If you have suggestions for additional ways to test the changes, then I'm happy to try them out as well.