### PR TITLE
Add Jump Kick only SB cannon tower climb + punch uppercut scout flies

### DIFF
--- a/worlds/jakanddaxter/__init__.py
+++ b/worlds/jakanddaxter/__init__.py
@@ -118,9 +118,9 @@ class JakAndDaxterWebWorld(WebWorld):
             options.SentinelBeachAttacklessPelican, # Shoot the Pelican with the cannon
         ]),
         OptionGroup("Tricks & Glitches - Medium", [
+            options.PunchUppercutScoutFlies,  # Some may be a little tricky
             options.GeyserRockCliffClimb, # You have to know where to jump, but the jump is not terribly difficult
             options.SandoverVillageCliffOrbCacheClimb, # Same here
-            options.SentinelBeachCannonTowerClimb, # Same here
             options.ForbiddenJungleElevatorSkip, # Deload glitch is easy, but hitting the loading zone can be tricky
             options.MistyIslandEarlyFarSideOrbCache, # Precise movement, but not too hard
             options.MistyIslandArenaFightSkip, # Drop down from top or use cannon to shoot enemies
@@ -135,6 +135,7 @@ class JakAndDaxterWebWorld(WebWorld):
         ]),
         OptionGroup("Tricks & Glitches - Hard", [
             options.BoostedAndExtendedUppercuts,
+            options.SentinelBeachCannonTowerClimb, # Climbing with only Jump Kick is hard, fish may eat Jak when failing
             options.ForbiddenJungleAttacklessSpiralStumpsScoutFly, # Precise movement from temple to power cell
             options.MistyIslandAttacklessScoutFlies, # Some require relatively precise movement with long runback
             options.BoggySwampFlutFlutEscape, # Harder trick, long runback

--- a/worlds/jakanddaxter/__init__.py
+++ b/worlds/jakanddaxter/__init__.py
@@ -121,6 +121,7 @@ class JakAndDaxterWebWorld(WebWorld):
             options.PunchUppercutScoutFlies,  # Some may be a little tricky
             options.GeyserRockCliffClimb, # You have to know where to jump, but the jump is not terribly difficult
             options.SandoverVillageCliffOrbCacheClimb, # Same here
+            options.SentinelBeachCannonTowerClimb, # Medium with Double Jump, hard with Jump Kick only
             options.ForbiddenJungleElevatorSkip, # Deload glitch is easy, but hitting the loading zone can be tricky
             options.MistyIslandEarlyFarSideOrbCache, # Precise movement, but not too hard
             options.MistyIslandArenaFightSkip, # Drop down from top or use cannon to shoot enemies
@@ -135,7 +136,6 @@ class JakAndDaxterWebWorld(WebWorld):
         ]),
         OptionGroup("Tricks & Glitches - Hard", [
             options.BoostedAndExtendedUppercuts,
-            options.SentinelBeachCannonTowerClimb, # Climbing with only Jump Kick is hard, fish may eat Jak when failing
             options.ForbiddenJungleAttacklessSpiralStumpsScoutFly, # Precise movement from temple to power cell
             options.MistyIslandAttacklessScoutFlies, # Some require relatively precise movement with long runback
             options.BoggySwampFlutFlutEscape, # Harder trick, long runback

--- a/worlds/jakanddaxter/__init__.py
+++ b/worlds/jakanddaxter/__init__.py
@@ -37,7 +37,7 @@ from .regions import create_regions
 from .rules import (enforce_mp_absolute_limits,
                     enforce_mp_friendly_limits,
                     enforce_sp_limits,
-                    set_orb_trade_rule)
+                    set_option_driven_rules)
 from .locs import (cell_locations as cells,
                    scout_locations as scouts,
                    special_locations as specials,
@@ -248,6 +248,13 @@ class JakAndDaxterWorld(World):
     # These functions and variables are Options-driven, keep them as instance variables here so that we don't clog up
     # the seed generation routines with options checking. So we set these once, and then just use them as needed.
     can_trade: Callable[[CollectionState, int, int | None], bool]
+
+    can_fight_or_roll_jump: Callable[[CollectionState, int], bool]
+    """Returns true if Jak can fight, including Roll Jump if the respective option is enabled."""
+
+    can_free_scout_flies: Callable[[CollectionState, int], bool]
+    """Returns true if Jak can break scout fly boxes, depending on the chosen options."""
+
     total_orbs: int = 2000
     orb_bundle_item_name: str = ""
     orb_bundle_size: int = 0
@@ -352,8 +359,8 @@ class JakAndDaxterWorld(World):
 
         self.trap_weights = self.options.trap_weights.weights_pair
 
-        # Options drive which trade rules to use, so they need to be setup before we create_regions.
-        set_orb_trade_rule(self)
+        # Options drive which trade rules to use and advanced logic, so they need to be setup before we create_regions.
+        set_option_driven_rules(self)
 
     # This will also set Locations, Location access rules, Region access rules, etc.
     def create_regions(self) -> None:

--- a/worlds/jakanddaxter/options.py
+++ b/worlds/jakanddaxter/options.py
@@ -326,6 +326,14 @@ class BoostedAndExtendedUppercuts(Toggle):
     display_name = "Boosted and Extended Uppercuts"
 
 
+class PunchUppercutScoutFlies(Toggle):
+    """
+    Treat punch uppercut as a valid move to break scout fly boxes. Enabling this setting may require Jak to break scout
+    fly boxes using only Punch Uppercut, even in confined spaces. This only applies if "Enable Move Randomizer" is ON.
+    """
+    display_name = "Punch Uppercut Scout Flies"
+
+
 class GeyserRockCliffClimb(Toggle):
     """
     Remove the movement requirement for the Geyser Rock Cliff. Enabling this setting may require Jak to use uneven
@@ -337,7 +345,8 @@ class GeyserRockCliffClimb(Toggle):
 class SentinelBeachCannonTowerClimb(Toggle):
     """
     Create an alternate path to the Sentinel Beach Cannon Tower. Enabling this setting may require Jak to use uneven
-    geometry to reach the cannon tower with only Double Jump. This only applies if "Enable Move Randomizer" is ON.
+    geometry to reach the cannon tower with only Jump Kick or only Double Jump.
+    This only applies if "Enable Move Randomizer" is ON.
     """
     display_name = "Sentinel Beach Cannon Tower Climb"
 
@@ -554,6 +563,7 @@ class JakAndDaxterOptions(PerGameCommonOptions):
     trap_effect_duration: TrapEffectDuration
     trap_weights: TrapWeights
     boosted_and_extended_uppercuts: BoostedAndExtendedUppercuts
+    punch_uppercut_scout_flies: PunchUppercutScoutFlies
     geyser_rock_cliff_climb: GeyserRockCliffClimb
     sentinel_beach_cannon_tower_climb: SentinelBeachCannonTowerClimb
     snowy_mountain_entrance_climb: SnowyMountainEntranceClimb

--- a/worlds/jakanddaxter/options.py
+++ b/worlds/jakanddaxter/options.py
@@ -342,13 +342,19 @@ class GeyserRockCliffClimb(Toggle):
     display_name = "Geyser Rock Cliff Climb"
 
 
-class SentinelBeachCannonTowerClimb(Toggle):
+class SentinelBeachCannonTowerClimb(Choice):
     """
     Create an alternate path to the Sentinel Beach Cannon Tower. Enabling this setting may require Jak to use uneven
-    geometry to reach the cannon tower with only Jump Kick or only Double Jump.
+    geometry to reach the cannon tower without having the Blue Eco Switch unlocked.
     This only applies if "Enable Move Randomizer" is ON.
+
+    Medium: Tower is climbable with only Double Jump
+    Hard: Tower is climbable with only Jump Kick too
     """
     display_name = "Sentinel Beach Cannon Tower Climb"
+    option_off = 0
+    option_medium = 1
+    option_hard = 2
 
 
 class SnowyMountainEntranceClimb(Toggle):

--- a/worlds/jakanddaxter/regs/forbidden_jungle_regions.py
+++ b/worlds/jakanddaxter/regs/forbidden_jungle_regions.py
@@ -4,13 +4,15 @@ from ..options import EnableOrbsanity
 from typing import TYPE_CHECKING
 if TYPE_CHECKING:
     from .. import JakAndDaxterWorld
-from ..rules import can_free_scout_flies, can_fight, can_reach_orbs_level
+from ..rules import can_fight, can_reach_orbs_level, get_can_free_scout_flies_fn
 
 
 def build_regions(level_name: str, world: "JakAndDaxterWorld") -> tuple[JakAndDaxterRegion, ...]:
     multiworld = world.multiworld
     options = world.options
     player = world.player
+
+    can_free_scout_flies = get_can_free_scout_flies_fn(options)
 
     # Define a helper function for all locations that can be acquired by regular fight moves or roll jump
     # We do not want to check the options each time we call those functions for performance reasons

--- a/worlds/jakanddaxter/regs/forbidden_jungle_regions.py
+++ b/worlds/jakanddaxter/regs/forbidden_jungle_regions.py
@@ -1,10 +1,9 @@
-from BaseClasses import CollectionState
 from .region_base import JakAndDaxterRegion
 from ..options import EnableOrbsanity
 from typing import TYPE_CHECKING
 if TYPE_CHECKING:
     from .. import JakAndDaxterWorld
-from ..rules import can_fight, can_reach_orbs_level, get_can_free_scout_flies_fn
+from ..rules import can_fight, can_reach_orbs_level
 
 
 def build_regions(level_name: str, world: "JakAndDaxterWorld") -> tuple[JakAndDaxterRegion, ...]:
@@ -12,16 +11,6 @@ def build_regions(level_name: str, world: "JakAndDaxterWorld") -> tuple[JakAndDa
     options = world.options
     player = world.player
 
-    can_free_scout_flies = get_can_free_scout_flies_fn(options)
-
-    # Define a helper function for all locations that can be acquired by regular fight moves or roll jump
-    # We do not want to check the options each time we call those functions for performance reasons
-    if options.attack_with_roll_jump:
-        def can_fight_or_roll_jump(state: CollectionState, p: int) -> bool:
-            return can_fight(state, p) or state.has_all(("Roll", "Roll Jump"), p)
-    else:
-        def can_fight_or_roll_jump(state: CollectionState, p: int) -> bool:
-            return can_fight(state, p)
 
     main_area = JakAndDaxterRegion("Main Area", player, multiworld, level_name, 25)
 
@@ -30,7 +19,7 @@ def build_regions(level_name: str, world: "JakAndDaxterWorld") -> tuple[JakAndDa
     main_area.add_fly_locations([393223])
 
     lurker_machine = JakAndDaxterRegion("Lurker Machine", player, multiworld, level_name, 5)
-    lurker_machine.add_cell_locations([3], access_rule=lambda state: can_fight_or_roll_jump(state, player))
+    lurker_machine.add_cell_locations([3], access_rule=lambda state: world.can_fight_or_roll_jump(state, player))
 
     # This cell and this scout fly can both be gotten with the blue eco clusters near the jump pad.
     lurker_machine.add_cell_locations([9])
@@ -51,7 +40,7 @@ def build_regions(level_name: str, world: "JakAndDaxterWorld") -> tuple[JakAndDa
         temple_exit.add_fly_locations([262151])
     else:
         # This fly is too far from accessible blue eco sources.
-        temple_exit.add_fly_locations([262151], access_rule=lambda state: can_free_scout_flies(state, player))
+        temple_exit.add_fly_locations([262151], access_rule=lambda state: world.can_free_scout_flies(state, player))
 
     temple_exterior = JakAndDaxterRegion("Temple Exterior", player, multiworld, level_name, 10)
 

--- a/worlds/jakanddaxter/regs/gol_and_maias_citadel_regions.py
+++ b/worlds/jakanddaxter/regs/gol_and_maias_citadel_regions.py
@@ -4,7 +4,7 @@ from ..options import EnableOrbsanity, CompletionCondition
 from typing import TYPE_CHECKING
 if TYPE_CHECKING:
     from .. import JakAndDaxterWorld
-from ..rules import can_fight, can_reach_orbs_level, get_can_free_scout_flies_fn
+from ..rules import can_fight, can_reach_orbs_level
 
 
 # God help me... here we go.
@@ -12,8 +12,6 @@ def build_regions(level_name: str, world: "JakAndDaxterWorld") -> tuple[JakAndDa
     multiworld = world.multiworld
     options = world.options
     player = world.player
-
-    can_free_scout_flies = get_can_free_scout_flies_fn(options)
 
     # This level is full of short-medium gaps that cannot be crossed by single jump alone. If you have the boosted
     # and extended uppercut option on, those moves are added as part of the function definition. We do NOT want to
@@ -34,10 +32,10 @@ def build_regions(level_name: str, world: "JakAndDaxterWorld") -> tuple[JakAndDa
                 or state.has_all(("Crouch", "Crouch Uppercut"), p))
 
     main_area = JakAndDaxterRegion("Main Area", player, multiworld, level_name, 0)
-    main_area.add_fly_locations([91], access_rule=lambda state: can_free_scout_flies(state, player))
+    main_area.add_fly_locations([91], access_rule=lambda state: world.can_free_scout_flies(state, player))
 
     robot_scaffolding = JakAndDaxterRegion("Scaffolding Around Robot", player, multiworld, level_name, 3)
-    robot_scaffolding.add_fly_locations([196699], access_rule=lambda state: can_free_scout_flies(state, player))
+    robot_scaffolding.add_fly_locations([196699], access_rule=lambda state: world.can_free_scout_flies(state, player))
 
     jump_pad_room = JakAndDaxterRegion("Jump Pad Chamber", player, multiworld, level_name, 88)
     jump_pad_room.add_cell_locations([73], access_rule=lambda state: can_fight(state, player))
@@ -48,7 +46,7 @@ def build_regions(level_name: str, world: "JakAndDaxterWorld") -> tuple[JakAndDa
     yellow_sage_scaffolding = JakAndDaxterRegion("Scaffolding Around Yellow Sage",
                                                  player, multiworld, level_name, 0)
     yellow_sage_scaffolding.add_fly_locations([65627], access_rule=lambda state:
-                                              can_free_scout_flies(state, player))
+                                              world.can_free_scout_flies(state, player))
 
     blast_furnace = JakAndDaxterRegion("Blast Furnace", player, multiworld, level_name, 44)
     blast_furnace.add_cell_locations([71], access_rule=lambda state: can_fight(state, player))
@@ -58,7 +56,7 @@ def build_regions(level_name: str, world: "JakAndDaxterWorld") -> tuple[JakAndDa
 
     # Does not include the orbs in the U turn itself, those belong to bunny room.
     u_turn_room = JakAndDaxterRegion("U-Turn Room", player, multiworld, level_name, 0)
-    u_turn_room.add_fly_locations([262235], access_rule=lambda state: can_free_scout_flies(state, player))
+    u_turn_room.add_fly_locations([262235], access_rule=lambda state: world.can_free_scout_flies(state, player))
 
     bunny_room = JakAndDaxterRegion("Bunny Chamber", player, multiworld, level_name, 45)
     bunny_room.add_cell_locations([72], access_rule=lambda state: can_fight(state, player))
@@ -67,7 +65,7 @@ def build_regions(level_name: str, world: "JakAndDaxterWorld") -> tuple[JakAndDa
     rotating_tower = JakAndDaxterRegion("Rotating Tower", player, multiworld, level_name, 20)
     rotating_tower.add_cell_locations([70], access_rule=lambda state: can_fight(state, player))
     rotating_tower.add_special_locations([70], access_rule=lambda state: can_fight(state, player))
-    rotating_tower.add_fly_locations([327771], access_rule=lambda state: can_free_scout_flies(state, player))
+    rotating_tower.add_fly_locations([327771], access_rule=lambda state: world.can_free_scout_flies(state, player))
 
     final_boss = JakAndDaxterRegion("Final Boss", player, multiworld, level_name, 0)
 

--- a/worlds/jakanddaxter/regs/gol_and_maias_citadel_regions.py
+++ b/worlds/jakanddaxter/regs/gol_and_maias_citadel_regions.py
@@ -4,7 +4,7 @@ from ..options import EnableOrbsanity, CompletionCondition
 from typing import TYPE_CHECKING
 if TYPE_CHECKING:
     from .. import JakAndDaxterWorld
-from ..rules import can_free_scout_flies, can_fight, can_reach_orbs_level
+from ..rules import can_fight, can_reach_orbs_level, get_can_free_scout_flies_fn
 
 
 # God help me... here we go.
@@ -12,6 +12,8 @@ def build_regions(level_name: str, world: "JakAndDaxterWorld") -> tuple[JakAndDa
     multiworld = world.multiworld
     options = world.options
     player = world.player
+
+    can_free_scout_flies = get_can_free_scout_flies_fn(options)
 
     # This level is full of short-medium gaps that cannot be crossed by single jump alone. If you have the boosted
     # and extended uppercut option on, those moves are added as part of the function definition. We do NOT want to

--- a/worlds/jakanddaxter/regs/lost_precursor_city_regions.py
+++ b/worlds/jakanddaxter/regs/lost_precursor_city_regions.py
@@ -3,13 +3,15 @@ from ..options import EnableOrbsanity
 from typing import TYPE_CHECKING
 if TYPE_CHECKING:
     from .. import JakAndDaxterWorld
-from ..rules import can_free_scout_flies, can_fight, can_reach_orbs_level
+from ..rules import can_fight, can_reach_orbs_level, get_can_free_scout_flies_fn
 
 
 def build_regions(level_name: str, world: "JakAndDaxterWorld") -> JakAndDaxterRegion:
     multiworld = world.multiworld
     options = world.options
     player = world.player
+
+    can_free_scout_flies = get_can_free_scout_flies_fn(options)
 
     # Just the starting area.
     main_area = JakAndDaxterRegion("Main Area", player, multiworld, level_name, 4)

--- a/worlds/jakanddaxter/regs/lost_precursor_city_regions.py
+++ b/worlds/jakanddaxter/regs/lost_precursor_city_regions.py
@@ -3,7 +3,7 @@ from ..options import EnableOrbsanity
 from typing import TYPE_CHECKING
 if TYPE_CHECKING:
     from .. import JakAndDaxterWorld
-from ..rules import can_fight, can_reach_orbs_level, get_can_free_scout_flies_fn
+from ..rules import can_fight, can_reach_orbs_level
 
 
 def build_regions(level_name: str, world: "JakAndDaxterWorld") -> JakAndDaxterRegion:
@@ -11,15 +11,13 @@ def build_regions(level_name: str, world: "JakAndDaxterWorld") -> JakAndDaxterRe
     options = world.options
     player = world.player
 
-    can_free_scout_flies = get_can_free_scout_flies_fn(options)
-
     # Just the starting area.
     main_area = JakAndDaxterRegion("Main Area", player, multiworld, level_name, 4)
 
     first_room_upper = JakAndDaxterRegion("First Chamber (Upper)", player, multiworld, level_name, 21)
 
     first_room_lower = JakAndDaxterRegion("First Chamber (Lower)", player, multiworld, level_name, 0)
-    first_room_lower.add_fly_locations([262193], access_rule=lambda state: can_free_scout_flies(state, player))
+    first_room_lower.add_fly_locations([262193], access_rule=lambda state: world.can_free_scout_flies(state, player))
 
     first_room_orb_cache = JakAndDaxterRegion("First Chamber Orb Cache", player, multiworld, level_name, 22)
 
@@ -28,7 +26,7 @@ def build_regions(level_name: str, world: "JakAndDaxterWorld") -> JakAndDaxterRe
                                              state.has_all(("Jump Dive", "Double Jump"), player))
 
     first_hallway = JakAndDaxterRegion("First Hallway", player, multiworld, level_name, 10)
-    first_hallway.add_fly_locations([131121], access_rule=lambda state: can_free_scout_flies(state, player))
+    first_hallway.add_fly_locations([131121], access_rule=lambda state: world.can_free_scout_flies(state, player))
 
     # This entire room is accessible with floating platforms and single jump.
     second_room = JakAndDaxterRegion("Second Chamber", player, multiworld, level_name, 28)
@@ -38,7 +36,7 @@ def build_regions(level_name: str, world: "JakAndDaxterWorld") -> JakAndDaxterRe
     second_room.add_fly_locations([49, 65585], access_rule=lambda state: state.has("Jump Dive", player))
 
     # This is the scout fly on the way to the pipe cell, requires normal breaking moves.
-    second_room.add_fly_locations([196657], access_rule=lambda state: can_free_scout_flies(state, player))
+    second_room.add_fly_locations([196657], access_rule=lambda state: world.can_free_scout_flies(state, player))
 
     # This orb vent and scout fly are right next to each other, can be gotten with blue eco and the floating platforms.
     second_room.add_fly_locations([393265])

--- a/worlds/jakanddaxter/regs/misty_island_regions.py
+++ b/worlds/jakanddaxter/regs/misty_island_regions.py
@@ -3,15 +3,13 @@ from ..options import EnableOrbsanity
 from typing import TYPE_CHECKING
 if TYPE_CHECKING:
     from .. import JakAndDaxterWorld
-from ..rules import can_fight, can_reach_orbs_level, get_can_free_scout_flies_fn
+from ..rules import can_fight, can_reach_orbs_level
 
 
 def build_regions(level_name: str, world: "JakAndDaxterWorld") -> JakAndDaxterRegion:
     multiworld = world.multiworld
     options = world.options
     player = world.player
-
-    can_free_scout_flies = get_can_free_scout_flies_fn(options)
 
     main_area = JakAndDaxterRegion("Main Area", player, multiworld, level_name, 9)
 
@@ -21,7 +19,7 @@ def build_regions(level_name: str, world: "JakAndDaxterWorld") -> JakAndDaxterRe
         # Grabbing blue eco orbs and running back can reach this scout fly
         muse_course.add_fly_locations([327708])
     else:
-        muse_course.add_fly_locations([327708], access_rule=lambda state: can_free_scout_flies(state, player))
+        muse_course.add_fly_locations([327708], access_rule=lambda state: world.can_free_scout_flies(state, player))
 
     zoomer = JakAndDaxterRegion("Zoomer", player, multiworld, level_name, 32)
     zoomer.add_cell_locations([27, 29])
@@ -29,13 +27,13 @@ def build_regions(level_name: str, world: "JakAndDaxterWorld") -> JakAndDaxterRe
 
     ship = JakAndDaxterRegion("Ship", player, multiworld, level_name, 10)
     ship.add_cell_locations([24])
-    ship.add_fly_locations([131100], access_rule=lambda state: can_free_scout_flies(state, player))
+    ship.add_fly_locations([131100], access_rule=lambda state: world.can_free_scout_flies(state, player))
 
     far_side = JakAndDaxterRegion("Far Side", player, multiworld, level_name, 16)
 
     # In order to even reach this fly, you must use the seesaw or crouch jump.
     far_side_cliff = JakAndDaxterRegion("Far Side Cliff", player, multiworld, level_name, 5)
-    far_side_cliff.add_fly_locations([28], access_rule=lambda state: can_free_scout_flies(state, player))
+    far_side_cliff.add_fly_locations([28], access_rule=lambda state: world.can_free_scout_flies(state, player))
 
     # To carry the blue eco fast enough to open this cache, you need to break the bone bridges along the way.
     far_side_cache = JakAndDaxterRegion("Far Side Orb Cache", player, multiworld, level_name, 15)
@@ -50,7 +48,7 @@ def build_regions(level_name: str, world: "JakAndDaxterWorld") -> JakAndDaxterRe
         # It's possible to break the scout fly by running into the explosive box next to it.
         barrel_course.add_fly_locations([196636])
     else:
-        barrel_course.add_fly_locations([196636], access_rule=lambda state: can_free_scout_flies(state, player))
+        barrel_course.add_fly_locations([196636], access_rule=lambda state: world.can_free_scout_flies(state, player))
 
     # 14 orbs for the boxes you can only break with the cannon.
     cannon = JakAndDaxterRegion("Cannon", player, multiworld, level_name, 14)
@@ -66,7 +64,7 @@ def build_regions(level_name: str, world: "JakAndDaxterWorld") -> JakAndDaxterRe
         upper_approach.add_fly_locations([65564, 262172])
     else:
         upper_approach.add_fly_locations([65564, 262172], access_rule=lambda state:
-                                         can_free_scout_flies(state, player))
+                                         world.can_free_scout_flies(state, player))
 
     lower_approach = JakAndDaxterRegion("Lower Arena Approach", player, multiworld, level_name, 7)
     lower_approach.add_cell_locations([30])

--- a/worlds/jakanddaxter/regs/misty_island_regions.py
+++ b/worlds/jakanddaxter/regs/misty_island_regions.py
@@ -3,13 +3,15 @@ from ..options import EnableOrbsanity
 from typing import TYPE_CHECKING
 if TYPE_CHECKING:
     from .. import JakAndDaxterWorld
-from ..rules import can_free_scout_flies, can_fight, can_reach_orbs_level
+from ..rules import can_fight, can_reach_orbs_level, get_can_free_scout_flies_fn
 
 
 def build_regions(level_name: str, world: "JakAndDaxterWorld") -> JakAndDaxterRegion:
     multiworld = world.multiworld
     options = world.options
     player = world.player
+
+    can_free_scout_flies = get_can_free_scout_flies_fn(options)
 
     main_area = JakAndDaxterRegion("Main Area", player, multiworld, level_name, 9)
 

--- a/worlds/jakanddaxter/regs/rock_village_regions.py
+++ b/worlds/jakanddaxter/regs/rock_village_regions.py
@@ -3,7 +3,7 @@ from ..options import EnableOrbsanity
 from typing import TYPE_CHECKING
 if TYPE_CHECKING:
     from .. import JakAndDaxterWorld
-from ..rules import can_reach_orbs_level, get_can_free_scout_flies_fn
+from ..rules import can_reach_orbs_level
 
 
 def build_regions(level_name: str, world: "JakAndDaxterWorld") -> tuple[JakAndDaxterRegion, ...]:
@@ -11,7 +11,6 @@ def build_regions(level_name: str, world: "JakAndDaxterWorld") -> tuple[JakAndDa
     options = world.options
     player = world.player
 
-    can_free_scout_flies = get_can_free_scout_flies_fn(options)
 
     # This includes most of the area surrounding LPC as well, for orb_count purposes. You can swim and single jump.
     main_area = JakAndDaxterRegion("Main Area", player, multiworld, level_name, 23)
@@ -24,7 +23,7 @@ def build_regions(level_name: str, world: "JakAndDaxterWorld") -> tuple[JakAndDa
     # These 2 scout fly boxes can be broken by running with nearby blue eco.
     main_area.add_fly_locations([196684, 262220])
     main_area.add_fly_locations([76, 131148, 65612, 327756], access_rule=lambda state:
-                                can_free_scout_flies(state, player))
+                                world.can_free_scout_flies(state, player))
 
     # Warrior Pontoon check. You just talk to him and get his introduction.
     main_area.add_special_locations([33])

--- a/worlds/jakanddaxter/regs/rock_village_regions.py
+++ b/worlds/jakanddaxter/regs/rock_village_regions.py
@@ -3,13 +3,15 @@ from ..options import EnableOrbsanity
 from typing import TYPE_CHECKING
 if TYPE_CHECKING:
     from .. import JakAndDaxterWorld
-from ..rules import can_free_scout_flies, can_reach_orbs_level
+from ..rules import can_reach_orbs_level, get_can_free_scout_flies_fn
 
 
 def build_regions(level_name: str, world: "JakAndDaxterWorld") -> tuple[JakAndDaxterRegion, ...]:
     multiworld = world.multiworld
     options = world.options
     player = world.player
+
+    can_free_scout_flies = get_can_free_scout_flies_fn(options)
 
     # This includes most of the area surrounding LPC as well, for orb_count purposes. You can swim and single jump.
     main_area = JakAndDaxterRegion("Main Area", player, multiworld, level_name, 23)

--- a/worlds/jakanddaxter/regs/sandover_village_regions.py
+++ b/worlds/jakanddaxter/regs/sandover_village_regions.py
@@ -3,13 +3,15 @@ from ..options import EnableOrbsanity
 from typing import TYPE_CHECKING
 if TYPE_CHECKING:
     from .. import JakAndDaxterWorld
-from ..rules import can_free_scout_flies, can_reach_orbs_level
+from ..rules import can_reach_orbs_level, get_can_free_scout_flies_fn
 
 
 def build_regions(level_name: str, world: "JakAndDaxterWorld") -> JakAndDaxterRegion:
     multiworld = world.multiworld
     options = world.options
     player = world.player
+
+    can_free_scout_flies = get_can_free_scout_flies_fn(options)
 
     main_area = JakAndDaxterRegion("Main Area", player, multiworld, level_name, 26)
 

--- a/worlds/jakanddaxter/regs/sandover_village_regions.py
+++ b/worlds/jakanddaxter/regs/sandover_village_regions.py
@@ -3,15 +3,13 @@ from ..options import EnableOrbsanity
 from typing import TYPE_CHECKING
 if TYPE_CHECKING:
     from .. import JakAndDaxterWorld
-from ..rules import can_reach_orbs_level, get_can_free_scout_flies_fn
+from ..rules import can_reach_orbs_level
 
 
 def build_regions(level_name: str, world: "JakAndDaxterWorld") -> JakAndDaxterRegion:
     multiworld = world.multiworld
     options = world.options
     player = world.player
-
-    can_free_scout_flies = get_can_free_scout_flies_fn(options)
 
     main_area = JakAndDaxterRegion("Main Area", player, multiworld, level_name, 26)
 
@@ -31,13 +29,13 @@ def build_regions(level_name: str, world: "JakAndDaxterWorld") -> JakAndDaxterRe
         main_area.add_fly_locations([196683], access_rule=lambda state:
                                     state.has("Double Jump", player)
                                     or state.has_all(("Crouch", "Crouch Jump"), player)
-                                    or can_free_scout_flies(state, player))
+                                    or world.can_free_scout_flies(state, player))
 
     orb_cache_cliff = JakAndDaxterRegion("Orb Cache Cliff", player, multiworld, level_name, 15)
     orb_cache_cliff.add_cache_locations([10344])
 
     yakow_cliff = JakAndDaxterRegion("Yakow Cliff", player, multiworld, level_name, 3)
-    yakow_cliff.add_fly_locations([75], access_rule=lambda state: can_free_scout_flies(state, player))
+    yakow_cliff.add_fly_locations([75], access_rule=lambda state: world.can_free_scout_flies(state, player))
 
     oracle_platforms = JakAndDaxterRegion("Oracle Platforms", player, multiworld, level_name, 6)
     oracle_platforms.add_cell_locations([13], access_rule=lambda state:
@@ -45,7 +43,7 @@ def build_regions(level_name: str, world: "JakAndDaxterWorld") -> JakAndDaxterRe
     oracle_platforms.add_cell_locations([14], access_rule=lambda state:
                                         world.can_trade(state, world.total_trade_orbs, 13))
     oracle_platforms.add_fly_locations([393291], access_rule=lambda state:
-                                       can_free_scout_flies(state, player))
+                                       world.can_free_scout_flies(state, player))
 
     if options.sandover_village_cliff_orb_cache_climb:
         # It is possible to reach this cliff (and the blue Eco next to it) with a single jump

--- a/worlds/jakanddaxter/regs/sentinel_beach_regions.py
+++ b/worlds/jakanddaxter/regs/sentinel_beach_regions.py
@@ -4,24 +4,13 @@ from ..options import EnableOrbsanity, SentinelBeachCannonTowerClimb
 from typing import TYPE_CHECKING
 if TYPE_CHECKING:
     from .. import JakAndDaxterWorld
-from ..rules import can_fight, can_reach_orbs_level, get_can_free_scout_flies_fn
+from ..rules import can_reach_orbs_level
 
 
 def build_regions(level_name: str, world: "JakAndDaxterWorld") -> JakAndDaxterRegion:
     multiworld = world.multiworld
     options = world.options
     player = world.player
-
-    can_free_scout_flies = get_can_free_scout_flies_fn(options)
-
-    # Define a helper function for all locations that can be acquired by regular fight moves or roll jump
-    # We do not want to check the options each time we call those functions for performance reasons
-    if options.attack_with_roll_jump:
-        def can_fight_or_roll_jump(state: CollectionState, p: int) -> bool:
-            return can_fight(state, p) or state.has_all(("Roll", "Roll Jump"), p)
-    else:
-        def can_fight_or_roll_jump(state: CollectionState, p: int) -> bool:
-            return can_fight(state, p)
 
     if options.sentinel_beach_cannon_tower_climb == SentinelBeachCannonTowerClimb.option_hard:
         def can_climb_cannon_tower(state: CollectionState, p: int) -> bool:
@@ -46,7 +35,7 @@ def build_regions(level_name: str, world: "JakAndDaxterWorld") -> JakAndDaxterRe
     # This scout fly box can be broken with the locked blue eco vent, or by normal combat tricks.
     main_area.add_fly_locations([393236], access_rule=lambda state:
                                 state.has("Blue Eco Switch", player)
-                                or can_free_scout_flies(state, player))
+                                or world.can_free_scout_flies(state, player))
 
     # No need for the blue eco vent for either of the orb caches.
     main_area.add_cache_locations([12634, 12635])
@@ -55,9 +44,9 @@ def build_regions(level_name: str, world: "JakAndDaxterWorld") -> JakAndDaxterRe
     if options.sentinel_beach_attackless_pelican:
         # Pelican power cell can be acquired by shooting the Pelican if the tower is accessible (no fight abilities needed)
         pelican.add_cell_locations([16], access_rule=lambda state:
-                                   can_fight_or_roll_jump(state, player) or can_reach_cannon(state, player))
+                                   world.can_fight_or_roll_jump(state, player) or can_reach_cannon(state, player))
     else:
-        pelican.add_cell_locations([16], access_rule=lambda state: can_fight_or_roll_jump(state, player))
+        pelican.add_cell_locations([16], access_rule=lambda state: world.can_fight_or_roll_jump(state, player))
 
     # Only these specific attacks can push the flut flut egg off the cliff.
     flut_flut_egg = JakAndDaxterRegion("Flut Flut Egg", player, multiworld, level_name, 0)
@@ -67,15 +56,15 @@ def build_regions(level_name: str, world: "JakAndDaxterWorld") -> JakAndDaxterRe
                                         state.has_any(("Punch", "Kick", "Jump Kick"), player))
 
     eco_harvesters = JakAndDaxterRegion("Eco Harvesters", player, multiworld, level_name, 0)
-    eco_harvesters.add_cell_locations([15], access_rule=lambda state: can_fight_or_roll_jump(state, player))
+    eco_harvesters.add_cell_locations([15], access_rule=lambda state: world.can_fight_or_roll_jump(state, player))
 
     green_ridge = JakAndDaxterRegion("Ridge Near Green Vents", player, multiworld, level_name, 5)
-    green_ridge.add_fly_locations([131092], access_rule=lambda state: can_free_scout_flies(state, player))
+    green_ridge.add_fly_locations([131092], access_rule=lambda state: world.can_free_scout_flies(state, player))
 
     blue_ridge = JakAndDaxterRegion("Ridge Near Blue Vent", player, multiworld, level_name, 5)
     blue_ridge.add_fly_locations([196628], access_rule=lambda state:
                                  state.has("Blue Eco Switch", player)
-                                 or can_free_scout_flies(state, player))
+                                 or world.can_free_scout_flies(state, player))
 
     rock_spires = JakAndDaxterRegion("Rock Spires", player, multiworld, level_name, 12)
 
@@ -84,7 +73,7 @@ def build_regions(level_name: str, world: "JakAndDaxterWorld") -> JakAndDaxterRe
         # It's possible to shoot the lurkers with their own cannon (or jump on them with the blue eco launcher)
         cannon_tower.add_cell_locations([19])
     else:
-        cannon_tower.add_cell_locations([19], access_rule=lambda state: can_fight_or_roll_jump(state, player))
+        cannon_tower.add_cell_locations([19], access_rule=lambda state: world.can_fight_or_roll_jump(state, player))
 
     main_area.connect(pelican)           # Swim and jump.
     main_area.connect(flut_flut_egg)     # Run and jump.

--- a/worlds/jakanddaxter/regs/sentinel_beach_regions.py
+++ b/worlds/jakanddaxter/regs/sentinel_beach_regions.py
@@ -4,13 +4,15 @@ from ..options import EnableOrbsanity
 from typing import TYPE_CHECKING
 if TYPE_CHECKING:
     from .. import JakAndDaxterWorld
-from ..rules import can_free_scout_flies, can_fight, can_reach_orbs_level
+from ..rules import can_fight, can_reach_orbs_level, get_can_free_scout_flies_fn
 
 
 def build_regions(level_name: str, world: "JakAndDaxterWorld") -> JakAndDaxterRegion:
     multiworld = world.multiworld
     options = world.options
     player = world.player
+
+    can_free_scout_flies = get_can_free_scout_flies_fn(options)
 
     # Define a helper function for all locations that can be acquired by regular fight moves or roll jump
     # We do not want to check the options each time we call those functions for performance reasons
@@ -40,10 +42,10 @@ def build_regions(level_name: str, world: "JakAndDaxterWorld") -> JakAndDaxterRe
     if options.sentinel_beach_attackless_pelican:
         # Pelican power cell can be acquired by shooting the Pelican if the tower is accessible (no fight abilities needed)
         if options.sentinel_beach_cannon_tower_climb:
-            # Tower can be reached with a double jump as well if the option is enabled
+            # Tower can be reached with a double jump (or Jump Kick) as well if the option is enabled
             pelican.add_cell_locations([16], access_rule=lambda state:
-                                       can_fight_or_roll_jump(state, player) or state.has("Blue Eco Switch", player)
-                                       or state.has("Double Jump", player))
+                                       can_fight_or_roll_jump(state, player)
+                                       or state.has_any(("Blue Eco Switch", "Double Jump", "Jump Kick"), player))
         else:
             # Otherwise, tower can only be reached by using the blue eco
             pelican.add_cell_locations([16], access_rule=lambda state:
@@ -104,7 +106,7 @@ def build_regions(level_name: str, world: "JakAndDaxterWorld") -> JakAndDaxterRe
 
     # An advanced way of reaching the cannon tower without Blue Eco Switch.
     if options.sentinel_beach_cannon_tower_climb:
-        main_area.connect(cannon_tower, rule=lambda state: state.has("Double Jump", player))
+        main_area.connect(cannon_tower, rule=lambda state: state.has_any(("Double Jump", "Jump Kick"), player))
 
     # All these can go back to main_area immediately.
     pelican.connect(main_area)

--- a/worlds/jakanddaxter/regs/snowy_mountain_regions.py
+++ b/worlds/jakanddaxter/regs/snowy_mountain_regions.py
@@ -4,7 +4,7 @@ from ..options import EnableOrbsanity
 from typing import TYPE_CHECKING
 if TYPE_CHECKING:
     from .. import JakAndDaxterWorld
-from ..rules import can_fight, can_reach_orbs_level, get_can_free_scout_flies_fn
+from ..rules import can_fight, can_reach_orbs_level
 
 
 # God help me... here we go.
@@ -14,8 +14,6 @@ def build_regions(level_name: str, world: "JakAndDaxterWorld") -> JakAndDaxterRe
     multiworld = world.multiworld
     options = world.options
     player = world.player
-
-    can_free_scout_flies = get_can_free_scout_flies_fn(options)
 
     # We need a few helper functions.
     def can_cross_long_gap(state: CollectionState, p: int) -> bool:
@@ -28,7 +26,7 @@ def build_regions(level_name: str, world: "JakAndDaxterWorld") -> JakAndDaxterRe
                 or state.has_all(("Punch", "Punch Uppercut"), p))
 
     main_area = JakAndDaxterRegion("Main Area", player, multiworld, level_name, 0)
-    main_area.add_fly_locations([65], access_rule=lambda state: can_free_scout_flies(state, player))
+    main_area.add_fly_locations([65], access_rule=lambda state: world.can_free_scout_flies(state, player))
 
     # We need a few virtual regions like we had for Dark Crystals in Spider Cave.
     # First, a virtual region for the glacier lurkers.
@@ -61,7 +59,7 @@ def build_regions(level_name: str, world: "JakAndDaxterWorld") -> JakAndDaxterRe
     frozen_box_cave = JakAndDaxterRegion("Frozen Box Cave", player, multiworld, level_name, 12)
     frozen_box_cave.add_fly_locations([327745], access_rule=lambda state:
                                       state.has("Yellow Eco Switch", player)
-                                      or can_free_scout_flies(state, player))
+                                      or world.can_free_scout_flies(state, player))
 
     # This region has crates that can *only* be broken with YES.
     frozen_box_cave_crates = JakAndDaxterRegion("Frozen Box Cave Orb Crates", player, multiworld, level_name, 8)
@@ -70,7 +68,7 @@ def build_regions(level_name: str, world: "JakAndDaxterWorld") -> JakAndDaxterRe
 
     # Include 6 orbs on the twin elevator ice ramp.
     ice_skating_rink = JakAndDaxterRegion("Ice Skating Rink", player, multiworld, level_name, 20)
-    ice_skating_rink.add_fly_locations([131137], access_rule=lambda state: can_free_scout_flies(state, player))
+    ice_skating_rink.add_fly_locations([131137], access_rule=lambda state: world.can_free_scout_flies(state, player))
 
     flut_flut_course = JakAndDaxterRegion("Flut Flut Course", player, multiworld, level_name, 15)
     flut_flut_course.add_cell_locations([63], access_rule=lambda state: state.has("Flut Flut", player))
@@ -79,7 +77,7 @@ def build_regions(level_name: str, world: "JakAndDaxterWorld") -> JakAndDaxterRe
     # Includes the bridge from snowball_canyon, the area beneath that bridge, and the areas around the fort.
     fort_exterior = JakAndDaxterRegion("Fort Exterior", player, multiworld, level_name, 20)
     fort_exterior.add_fly_locations([65601, 393281], access_rule=lambda state:
-                                    can_free_scout_flies(state, player))
+                                    world.can_free_scout_flies(state, player))
 
     # Includes the icy island and bridge outside the cave entrance.
     bunny_cave_start = JakAndDaxterRegion("Bunny Cave (Start)", player, multiworld, level_name, 10)
@@ -103,7 +101,7 @@ def build_regions(level_name: str, world: "JakAndDaxterWorld") -> JakAndDaxterRe
     # Need higher jump.
     fort_interior_base = JakAndDaxterRegion("Fort Interior (Base)", player, multiworld, level_name, 0)
     fort_interior_base.add_fly_locations([262209], access_rule=lambda state:
-                                         can_free_scout_flies(state, player))
+                                         world.can_free_scout_flies(state, player))
 
     # Need farther jump.
     fort_interior_course_end = JakAndDaxterRegion("Fort Interior (Course End)", player, multiworld, level_name, 2)
@@ -228,8 +226,6 @@ def build_regions_with_flut_flut(level_name: str, world: "JakAndDaxterWorld") ->
     options = world.options
     player = world.player
 
-    can_free_scout_flies = get_can_free_scout_flies_fn(options)
-
     # We need a few helper functions.
     def can_cross_long_gap(state: CollectionState, p: int) -> bool:
         return (state.has_all(("Roll", "Roll Jump"), p)
@@ -241,7 +237,7 @@ def build_regions_with_flut_flut(level_name: str, world: "JakAndDaxterWorld") ->
                 or state.has_all(("Punch", "Punch Uppercut"), p))
 
     main_area = JakAndDaxterRegion("Main Area", player, multiworld, level_name, 0)
-    main_area.add_fly_locations([65], access_rule=lambda state: can_free_scout_flies(state, player))
+    main_area.add_fly_locations([65], access_rule=lambda state: world.can_free_scout_flies(state, player))
 
     # We need a few virtual regions like we had for Dark Crystals in Spider Cave.
     # First, a virtual region for the glacier lurkers.
@@ -274,7 +270,7 @@ def build_regions_with_flut_flut(level_name: str, world: "JakAndDaxterWorld") ->
     frozen_box_cave = JakAndDaxterRegion("Frozen Box Cave", player, multiworld, level_name, 12)
     frozen_box_cave.add_fly_locations([327745], access_rule=lambda state:
                                       state.has_any(("Flut Flut", "Yellow Eco Switch"), player)
-                                      or can_free_scout_flies(state, player))
+                                      or world.can_free_scout_flies(state, player))
 
     # This region has crates that can *only* be broken with YES.
     frozen_box_cave_crates = JakAndDaxterRegion("Frozen Box Cave Orb Crates", player, multiworld, level_name, 8)
@@ -283,7 +279,7 @@ def build_regions_with_flut_flut(level_name: str, world: "JakAndDaxterWorld") ->
 
     # Include 6 orbs on the twin elevator ice ramp.
     ice_skating_rink = JakAndDaxterRegion("Ice Skating Rink", player, multiworld, level_name, 20)
-    ice_skating_rink.add_fly_locations([131137], access_rule=lambda state: can_free_scout_flies(state, player))
+    ice_skating_rink.add_fly_locations([131137], access_rule=lambda state: world.can_free_scout_flies(state, player))
 
     flut_flut_course = JakAndDaxterRegion("Flut Flut Course", player, multiworld, level_name, 15)
     flut_flut_course.add_cell_locations([63], access_rule=lambda state: state.has("Flut Flut", player))
@@ -293,7 +289,7 @@ def build_regions_with_flut_flut(level_name: str, world: "JakAndDaxterWorld") ->
     fort_exterior = JakAndDaxterRegion("Fort Exterior", player, multiworld, level_name, 20)
     fort_exterior.add_fly_locations([65601, 393281], access_rule=lambda state:
                                     state.has("Flut Flut", player)
-                                    or can_free_scout_flies(state, player))
+                                    or world.can_free_scout_flies(state, player))
 
     # Includes the icy island and bridge outside the cave entrance.
     bunny_cave_start = JakAndDaxterRegion("Bunny Cave (Start)", player, multiworld, level_name, 10)
@@ -318,7 +314,7 @@ def build_regions_with_flut_flut(level_name: str, world: "JakAndDaxterWorld") ->
     fort_interior_base = JakAndDaxterRegion("Fort Interior (Base)", player, multiworld, level_name, 0)
     fort_interior_base.add_fly_locations([262209], access_rule=lambda state:
                                          state.has("Flut Flut", player)
-                                         or can_free_scout_flies(state, player))
+                                         or world.can_free_scout_flies(state, player))
 
     # Need farther jump.
     fort_interior_course_end = JakAndDaxterRegion("Fort Interior (Course End)", player, multiworld, level_name, 2)

--- a/worlds/jakanddaxter/regs/snowy_mountain_regions.py
+++ b/worlds/jakanddaxter/regs/snowy_mountain_regions.py
@@ -4,7 +4,7 @@ from ..options import EnableOrbsanity
 from typing import TYPE_CHECKING
 if TYPE_CHECKING:
     from .. import JakAndDaxterWorld
-from ..rules import can_free_scout_flies, can_fight, can_reach_orbs_level
+from ..rules import can_fight, can_reach_orbs_level, get_can_free_scout_flies_fn
 
 
 # God help me... here we go.
@@ -14,6 +14,8 @@ def build_regions(level_name: str, world: "JakAndDaxterWorld") -> JakAndDaxterRe
     multiworld = world.multiworld
     options = world.options
     player = world.player
+
+    can_free_scout_flies = get_can_free_scout_flies_fn(options)
 
     # We need a few helper functions.
     def can_cross_long_gap(state: CollectionState, p: int) -> bool:
@@ -225,6 +227,8 @@ def build_regions_with_flut_flut(level_name: str, world: "JakAndDaxterWorld") ->
     multiworld = world.multiworld
     options = world.options
     player = world.player
+
+    can_free_scout_flies = get_can_free_scout_flies_fn(options)
 
     # We need a few helper functions.
     def can_cross_long_gap(state: CollectionState, p: int) -> bool:

--- a/worlds/jakanddaxter/regs/spider_cave_regions.py
+++ b/worlds/jakanddaxter/regs/spider_cave_regions.py
@@ -3,15 +3,13 @@ from ..options import EnableOrbsanity
 from typing import TYPE_CHECKING
 if TYPE_CHECKING:
     from .. import JakAndDaxterWorld
-from ..rules import can_fight, can_reach_orbs_level, get_can_free_scout_flies_fn
+from ..rules import can_fight, can_reach_orbs_level
 
 
 def build_regions(level_name: str, world: "JakAndDaxterWorld") -> JakAndDaxterRegion:
     multiworld = world.multiworld
     options = world.options
     player = world.player
-
-    can_free_scout_flies = get_can_free_scout_flies_fn(options)
 
     # A large amount of this area can be covered by single jump, floating platforms, web trampolines, and goggles.
     main_area = JakAndDaxterRegion("Main Area", player, multiworld, level_name, 63)
@@ -32,7 +30,7 @@ def build_regions(level_name: str, world: "JakAndDaxterWorld") -> JakAndDaxterRe
 
     dark_cave = JakAndDaxterRegion("Dark Cave", player, multiworld, level_name, 5)
     dark_cave.add_cell_locations([80])
-    dark_cave.add_fly_locations([262229], access_rule=lambda state: can_free_scout_flies(state, player))
+    dark_cave.add_fly_locations([262229], access_rule=lambda state: world.can_free_scout_flies(state, player))
 
     robot_cave = JakAndDaxterRegion("Robot Cave", player, multiworld, level_name, 0)
 

--- a/worlds/jakanddaxter/regs/spider_cave_regions.py
+++ b/worlds/jakanddaxter/regs/spider_cave_regions.py
@@ -3,13 +3,15 @@ from ..options import EnableOrbsanity
 from typing import TYPE_CHECKING
 if TYPE_CHECKING:
     from .. import JakAndDaxterWorld
-from ..rules import can_free_scout_flies, can_fight, can_reach_orbs_level
+from ..rules import can_fight, can_reach_orbs_level, get_can_free_scout_flies_fn
 
 
 def build_regions(level_name: str, world: "JakAndDaxterWorld") -> JakAndDaxterRegion:
     multiworld = world.multiworld
     options = world.options
     player = world.player
+
+    can_free_scout_flies = get_can_free_scout_flies_fn(options)
 
     # A large amount of this area can be covered by single jump, floating platforms, web trampolines, and goggles.
     main_area = JakAndDaxterRegion("Main Area", player, multiworld, level_name, 63)

--- a/worlds/jakanddaxter/regs/volcanic_crater_regions.py
+++ b/worlds/jakanddaxter/regs/volcanic_crater_regions.py
@@ -3,7 +3,7 @@ from ..options import EnableOrbsanity
 from typing import TYPE_CHECKING
 if TYPE_CHECKING:
     from .. import JakAndDaxterWorld
-from ..rules import can_free_scout_flies, can_reach_orbs_level
+from ..rules import can_reach_orbs_level, get_can_free_scout_flies_fn
 from ..locs import scout_locations as scouts
 
 
@@ -11,6 +11,8 @@ def build_regions(level_name: str, world: "JakAndDaxterWorld") -> JakAndDaxterRe
     multiworld = world.multiworld
     options = world.options
     player = world.player
+
+    can_free_scout_flies = get_can_free_scout_flies_fn(options)
 
     # No area is inaccessible in VC even with only running and jumping.
     main_area = JakAndDaxterRegion("Main Area", player, multiworld, level_name, 50)

--- a/worlds/jakanddaxter/regs/volcanic_crater_regions.py
+++ b/worlds/jakanddaxter/regs/volcanic_crater_regions.py
@@ -3,7 +3,7 @@ from ..options import EnableOrbsanity
 from typing import TYPE_CHECKING
 if TYPE_CHECKING:
     from .. import JakAndDaxterWorld
-from ..rules import can_reach_orbs_level, get_can_free_scout_flies_fn
+from ..rules import can_reach_orbs_level
 from ..locs import scout_locations as scouts
 
 
@@ -11,8 +11,6 @@ def build_regions(level_name: str, world: "JakAndDaxterWorld") -> JakAndDaxterRe
     multiworld = world.multiworld
     options = world.options
     player = world.player
-
-    can_free_scout_flies = get_can_free_scout_flies_fn(options)
 
     # No area is inaccessible in VC even with only running and jumping.
     main_area = JakAndDaxterRegion("Main Area", player, multiworld, level_name, 50)
@@ -29,7 +27,7 @@ def build_regions(level_name: str, world: "JakAndDaxterWorld") -> JakAndDaxterRe
 
     # No blue eco sources in this area, all boxes must be broken by hand (yellow eco can't be carried far enough).
     main_area.add_fly_locations(scouts.locVC_scoutTable.keys(), access_rule=lambda state:
-                                can_free_scout_flies(state, player))
+                                world.can_free_scout_flies(state, player))
 
     # Approach the gondola to get this check.
     main_area.add_special_locations([105])


### PR DESCRIPTION
### SB Tower Climb
I've found out in my Archipelago run that Sentinel Beach cannon tower climb is actually possible with only Jump Kick, so I added it (but I moved it to the "hard tricks" option section as it may require a few attempts and the fish likes to Jak, requiring him to run back all the time).

### Punch Uppercut Scoutflies
Additionally, I've broken every scout fly box with only Punch Uppercut and can confirm that it's indeed possible. Some are a bit tricky, so I added it to the "medium" difficulty. Since `can_free_scout_flies` is used everywhere, I've created a helper function that returns the correct function, depending on the options. This shouldn't have any drastic performance implications as the option checking is still only done once per region, and the access rule evaluation doesn't need the option anymore.

## Testing

Unit Tests are green, and on my PC I got 3000/3000 Successes on the fuzzer together with an empty apworld with 100 locations (same result with 70 locations as well).

I've used debug mode to fly to every scout fly box and broke them with punch uppercut to make sure there is enough space for it. For some scout flies, that may require starting at a nearby platform (e.g. FJ "Scout Fly On Spiral Of Stumps"), but all were possible.

I haven't done a separate run with these changes yet as they are pretty minor (and I was just doing an Archipelago with the previous settings) - but I'm planning on doing another run in the next 1-2 weeks.