### PR TITLE
Advanced Movement: Snowy Mountain

### DIFF
--- a/worlds/jakanddaxter/__init__.py
+++ b/worlds/jakanddaxter/__init__.py
@@ -118,20 +118,21 @@ class JakAndDaxterWebWorld(WebWorld):
             options.SentinelBeachAttacklessPelican, # Shoot the Pelican with the cannon.
         ]),
         OptionGroup("Tricks & Glitches - Medium", [
-            options.PunchUppercutScoutFlies,  # Some may be a little tricky
-            options.GeyserRockCliffClimb, # You have to know where to jump, but the jump is not terribly difficult
-            options.SandoverVillageCliffOrbCacheClimb, # Same here
-            options.SentinelBeachCannonTowerClimb, # Medium with Double Jump, hard with Jump Kick only
-            options.ForbiddenJungleElevatorSkip, # Deload glitch is easy, but hitting the loading zone can be tricky
-            options.MistyIslandEarlyFarSideOrbCache, # Precise movement, but not too hard
-            options.MistyIslandArenaFightSkip, # Drop down from top or use cannon to shoot enemies
-            options.MistyIslandFarSideCliffSeesawSkip, # Relatively easy, but route is not obvious
-            options.RockVillageEarlyOrbCache, # Precise movement, but not too hard, fast retries possible
-            options.RockVillagePontoonSkip, # May require fast swimming, but not too tight
-            options.KlawwCliffClimb, # Easy when out of bounds spot is known
-            options.KlawwBoulderSkip, # Same trick as above
-            options.BoggySwampPreciseMovement, # Mostly just taking damage on some jumps to get to the next checkpoint
-            options.SnowyMountainEntranceClimb, # Jump onto the wall on the left and simply slide over
+            options.PunchUppercutScoutFlies,  # Some may be a little tricky.
+            options.GeyserRockCliffClimb, # You have to know where to jump, but the jump is not terribly difficult.
+            options.SandoverVillageCliffOrbCacheClimb, # Same here.
+            options.SentinelBeachCannonTowerClimb, # Medium with Double Jump, hard with Jump Kick only.
+            options.ForbiddenJungleElevatorSkip, # Deload glitch is easy, but hitting the loading zone can be tricky.
+            options.MistyIslandEarlyFarSideOrbCache, # Precise movement, but not too hard.
+            options.MistyIslandArenaFightSkip, # Drop down from top or use cannon to shoot enemies.
+            options.MistyIslandFarSideCliffSeesawSkip, # Relatively easy, but route is not obvious.
+            options.RockVillageEarlyOrbCache, # Precise movement, but not too hard, fast retries possible.
+            options.RockVillagePontoonSkip, # May require fast swimming, but not too tight.
+            options.KlawwCliffClimb, # Easy when out of bounds spot is known.
+            options.KlawwBoulderSkip, # Same trick as above.
+            options.BoggySwampPreciseMovement, # Mostly just taking damage on some jumps to get to the next checkpoint.
+            options.SnowyMountainEntranceClimb, # Jump onto the wall on the left and simply slide over.
+            options.SnowyMountainFlutFlutSkip, # Easily reachable by Zoom Walking.
         ]),
         OptionGroup("Tricks & Glitches - Hard", [
             options.BoostedAndExtendedUppercuts,
@@ -141,7 +142,7 @@ class JakAndDaxterWebWorld(WebWorld):
             options.BoggySwampAttacklessAmbush, # Doing the lurker ambush without attacks is annoying (and hard).
             options.BoggySwampFlutFlutSkip, # Flut Flut course with only Roll Jump requires precise jumping.
             options.LostPrecursorCitySingleJumpSlideTubeClimb, # Climbing the tube without attacks/moves is hard.
-            options.SnowyMountainFlutFlutEscape,  # Escaping is easy, doing the whole level can be tricky though
+            options.SnowyMountainFlutFlutEscape,  # Escaping is easy, doing the whole level can be tricky though.
         ]),
         OptionGroup("Traps", [
             options.FillerPowerCellsReplacedWithTraps,

--- a/worlds/jakanddaxter/__init__.py
+++ b/worlds/jakanddaxter/__init__.py
@@ -96,6 +96,8 @@ class JakAndDaxterWebWorld(WebWorld):
     tutorials = [setup_en]
     bug_report_page = "https://github.com/ArchipelaGOAL/Archipelago/issues"
 
+    rich_text_options_doc = True
+
     option_groups = [
         OptionGroup("Orbsanity", [
             options.EnableOrbsanity,

--- a/worlds/jakanddaxter/__init__.py
+++ b/worlds/jakanddaxter/__init__.py
@@ -113,9 +113,9 @@ class JakAndDaxterWebWorld(WebWorld):
             options.OracleOrbTradeAmount,
         ]),
         OptionGroup("Tricks & Glitches - Easy", [
-            options.AttackWithRollJump,  # Use Roll Jump instead of regular attacks to hit certain targets
-            options.AttacklessLurkerCannons, # Shoot the lurkers with their own cannon
-            options.SentinelBeachAttacklessPelican, # Shoot the Pelican with the cannon
+            options.AttackWithRollJump,  # Use Roll Jump instead of regular attacks to hit certain targets.
+            options.AttacklessLurkerCannons, # Shoot the lurkers with their own cannon.
+            options.SentinelBeachAttacklessPelican, # Shoot the Pelican with the cannon.
         ]),
         OptionGroup("Tricks & Glitches - Medium", [
             options.PunchUppercutScoutFlies,  # Some may be a little tricky
@@ -132,16 +132,16 @@ class JakAndDaxterWebWorld(WebWorld):
             options.KlawwBoulderSkip, # Same trick as above
             options.BoggySwampPreciseMovement, # Mostly just taking damage on some jumps to get to the next checkpoint
             options.SnowyMountainEntranceClimb, # Jump onto the wall on the left and simply slide over
-            options.SnowyMountainFlutFlutEscape,
         ]),
         OptionGroup("Tricks & Glitches - Hard", [
             options.BoostedAndExtendedUppercuts,
-            options.ForbiddenJungleAttacklessSpiralStumpsScoutFly, # Precise movement from temple to power cell
-            options.MistyIslandAttacklessScoutFlies, # Some require relatively precise movement with long runback
-            options.BoggySwampFlutFlutEscape, # Harder trick, long runback
-            options.BoggySwampAttacklessAmbush, # Doing the lurker ambush without attacks is annoying (and hard)
-            options.BoggySwampFlutFlutSkip, # Flut Flut course with only Roll Jump requires precise jumping
-            options.LostPrecursorCitySingleJumpSlideTubeClimb, # Climbing the tube without attacks/moves is hard
+            options.ForbiddenJungleAttacklessSpiralStumpsScoutFly, # Precise movement from temple to power cell.
+            options.MistyIslandAttacklessScoutFlies, # Some require relatively precise movement with long runback.
+            options.BoggySwampFlutFlutEscape, # Harder trick, long runback.
+            options.BoggySwampAttacklessAmbush, # Doing the lurker ambush without attacks is annoying (and hard).
+            options.BoggySwampFlutFlutSkip, # Flut Flut course with only Roll Jump requires precise jumping.
+            options.LostPrecursorCitySingleJumpSlideTubeClimb, # Climbing the tube without attacks/moves is hard.
+            options.SnowyMountainFlutFlutEscape,  # Escaping is easy, doing the whole level can be tricky though
         ]),
         OptionGroup("Traps", [
             options.FillerPowerCellsReplacedWithTraps,

--- a/worlds/jakanddaxter/options.py
+++ b/worlds/jakanddaxter/options.py
@@ -357,13 +357,18 @@ class SentinelBeachCannonTowerClimb(Choice):
     option_hard = 2
 
 
-class SnowyMountainEntranceClimb(Toggle):
+class SnowyMountainEntranceClimb(Choice):
     """
     Create an alternate path into Snowy Mountain. Enabling this setting may require Jak to use uneven geometry to reach
-    Snowy Mountain's main area with only Double Jump or Crouch Jump. This only applies if "Enable Move Randomizer"
-    is ON.
+    Snowy Mountain's main area with fewer move options. This only applies if "Enable Move Randomizer" is ON.
+
+    Medium: only Double Jump or Crouch Jump
+    Hard: only Single Jump
     """
     display_name = "Snowy Mountain Entrance Climb"
+    option_off = 0
+    option_medium = 1
+    option_hard = 2
 
 
 class BoggySwampFlutFlutEscape(Toggle):
@@ -378,9 +383,17 @@ class BoggySwampFlutFlutEscape(Toggle):
 class SnowyMountainFlutFlutEscape(Toggle):
     """
     Changes Snowy Mountain to rely on Flut Flut for movement. Enabling this setting may require Jak to get Flut Flut
-    over an invisible barrier to access nearly all of Snowy Mountain.
+    over an invisible barrier to access all of Snowy Mountain.
     """
     display_name = "Snowy Mountain Flut Flut Escape"
+
+
+class SnowyMountainFlutFlutSkip(Toggle):
+    """
+    Create an alternative path to the end of the Flut Flut course in Snowy Mountain. Enabling this setting may require
+    Jak to use advanced movement tricks to reach the end of the Flut Flut course with only Single Jump and no Flut Flut.
+    """
+    display_name = "Snowy Mountain Flut Flut Skip"
 
 
 class SandoverVillageCliffOrbCacheClimb(Toggle):
@@ -575,6 +588,7 @@ class JakAndDaxterOptions(PerGameCommonOptions):
     snowy_mountain_entrance_climb: SnowyMountainEntranceClimb
     boggy_swamp_flut_flut_escape: BoggySwampFlutFlutEscape
     snowy_mountain_flut_flut_escape: SnowyMountainFlutFlutEscape
+    snowy_mountain_flut_flut_skip: SnowyMountainFlutFlutSkip
     sandover_village_cliff_orb_cache_climb: SandoverVillageCliffOrbCacheClimb
     attackless_lurker_cannons: AttacklessLurkerCannons
     sentinel_beach_attackless_pelican: SentinelBeachAttacklessPelican

--- a/worlds/jakanddaxter/options.py
+++ b/worlds/jakanddaxter/options.py
@@ -87,8 +87,9 @@ class EnableOrbsanity(Choice):
     """Include bundles of Precursor Orbs as checks. Every time you collect the chosen number of orbs, you will trigger
     another check.
 
-    Per Level: bundles are for each level in the game.
-    Global: bundles carry over level to level.
+    **Per Level:** bundles are for each level in the game.
+
+    **Global:** bundles carry over level to level.
 
     This adds a number of Items and Locations to the pool inversely proportional to the size of the bundle.
     For example, if your bundle size is 20 orbs, you will add 100 items to the pool. If your bundle size is 250 orbs,
@@ -183,9 +184,10 @@ class PerLevelOrbsanityBundleSize(AllowedChoice):
 
 
 class FireCanyonCellCount(Range):
-    """The number of power cells you need to cross Fire Canyon. This value is restricted to a safe maximum value to
-    ensure valid singleplayer games and non-disruptive multiplayer games, but the host can remove this restriction by
-    turning off enforce_friendly_options in host.yaml."""
+    """The number of power cells you need to cross Fire Canyon.
+
+    This value is restricted to a safe maximum value to ensure valid singleplayer games and non-disruptive multiplayer
+    games, but the host can remove this restriction by turning off enforce_friendly_options in host.yaml."""
     display_name = "Fire Canyon Cell Count"
     friendly_maximum = 30
     absolute_maximum = 100
@@ -195,9 +197,10 @@ class FireCanyonCellCount(Range):
 
 
 class MountainPassCellCount(Range):
-    """The number of power cells you need to reach Klaww and cross Mountain Pass. This value is restricted to a safe
-    maximum value to ensure valid singleplayer games and non-disruptive multiplayer games, but the host can
-    remove this restriction by turning off enforce_friendly_options in host.yaml."""
+    """The number of power cells you need to reach Klaww and cross Mountain Pass.
+
+    This value is restricted to a safe maximum value to ensure valid singleplayer games and non-disruptive multiplayer
+    games, but the host can remove this restriction by turning off enforce_friendly_options in host.yaml."""
     display_name = "Mountain Pass Cell Count"
     friendly_maximum = 60
     absolute_maximum = 100
@@ -207,9 +210,10 @@ class MountainPassCellCount(Range):
 
 
 class LavaTubeCellCount(Range):
-    """The number of power cells you need to cross Lava Tube. This value is restricted to a safe maximum value to
-    ensure valid singleplayer games and non-disruptive multiplayer games, but the host can remove this restriction by
-    turning off enforce_friendly_options in host.yaml."""
+    """The number of power cells you need to cross Lava Tube.
+
+    This value is restricted to a safe maximum value to ensure valid singleplayer games and non-disruptive multiplayer
+    games, but the host can remove this restriction by turning off enforce_friendly_options in host.yaml."""
     display_name = "Lava Tube Cell Count"
     friendly_maximum = 90
     absolute_maximum = 100
@@ -227,8 +231,11 @@ class EnableOrderedCellCounts(DefaultOnToggle):
 
 
 class RequirePunchForKlaww(DefaultOnToggle):
-    """Force the Punch move to come before Klaww. Disabling this setting may require Jak to fight Klaww
-    and Gol and Maia by shooting yellow eco through his goggles. This only applies if "Enable Move Randomizer" is ON."""
+    """Force the Punch move to come before Klaww.
+
+    Disabling this setting may require Jak to fight Klaww and Gol and Maia by shooting yellow eco through his goggles.
+
+    This only applies if "Enable Move Randomizer" is ON."""
     display_name = "Require Punch For Klaww"
 
 
@@ -320,86 +327,112 @@ class TrapWeights(OptionCounter):
 
 class BoostedAndExtendedUppercuts(Toggle):
     """
-    Create alternate paths to some areas with advanced movement. Enabling this setting may require Jak to use boosted
-    and extended uppercuts as opposed to regular movement options. This only applies if "Enable Move Randomizer" is ON.
+    Create alternate paths to some areas with advanced movement.
+
+    Enabling this setting may require Jak to use boosted and extended uppercuts as opposed to regular movement options.
+
+    This only applies if "Enable Move Randomizer" is ON.
     """
     display_name = "Boosted and Extended Uppercuts"
 
 
 class PunchUppercutScoutFlies(Toggle):
     """
-    Treat punch uppercut as a valid move to break scout fly boxes. Enabling this setting may require Jak to break scout
-    fly boxes using only Punch Uppercut, even in confined spaces. This only applies if "Enable Move Randomizer" is ON.
+    Treat *Punch Uppercut* as a valid move to break scout fly boxes.
+
+    Enabling this setting may require Jak to break scout fly boxes using only *Punch Uppercut*, even in confined spaces.
+
+    This only applies if "Enable Move Randomizer" is ON.
     """
     display_name = "Punch Uppercut Scout Flies"
 
 
 class GeyserRockCliffClimb(Toggle):
     """
-    Remove the movement requirement for the Geyser Rock Cliff. Enabling this setting may require Jak to use uneven
-    terrain to reach the cliff with only Single Jump. This only applies if "Enable Move Randomizer" is ON.
+    Remove the movement requirement for the Geyser Rock Cliff.
+
+    Enabling this setting may require Jak to use uneven terrain to reach the cliff with only *Single Jump*.
+
+    This only applies if "Enable Move Randomizer" is ON.
     """
     display_name = "Geyser Rock Cliff Climb"
 
 
 class SentinelBeachCannonTowerClimb(Choice):
     """
-    Create an alternate path to the Sentinel Beach Cannon Tower. Enabling this setting may require Jak to use uneven
-    geometry to reach the cannon tower without having the Blue Eco Switch unlocked.
-    This only applies if "Enable Move Randomizer" is ON.
+    Create an alternate path to the Sentinel Beach Cannon Tower.
 
-    Medium: Tower is climbable with only Double Jump
-    Hard: Tower is climbable with only Jump Kick too
+    Enabling this setting may require Jak to use uneven geometry to reach the cannon tower without having the
+    *Blue Eco Switch* unlocked.
+
+    **Medium:** Tower is climbable with only *Double Jump*.
+
+    **Hard:** Tower is climbable with only *Jump Kick* or only *Double Jump*.
+
+    This only applies if "Enable Move Randomizer" is ON.
     """
     display_name = "Sentinel Beach Cannon Tower Climb"
-    option_off = 0
+    option_no = 0
     option_medium = 1
     option_hard = 2
 
 
 class SnowyMountainEntranceClimb(Choice):
     """
-    Create an alternate path into Snowy Mountain. Enabling this setting may require Jak to use uneven geometry to reach
-    Snowy Mountain's main area with fewer move options. This only applies if "Enable Move Randomizer" is ON.
+    Create an alternate path into Snowy Mountain.
 
-    Medium: only Double Jump or Crouch Jump
-    Hard: only Single Jump
+    Enabling this setting may require Jak to use uneven geometry to reach Snowy Mountain's main area with fewer move
+    options.
+
+    **Medium:** only *Double Jump* or *Crouch Jump*
+
+    **Hard:** only *Single Jump*
+
+    This only applies if "Enable Move Randomizer" is ON.
     """
     display_name = "Snowy Mountain Entrance Climb"
-    option_off = 0
+    option_no = 0
     option_medium = 1
     option_hard = 2
 
 
 class BoggySwampFlutFlutEscape(Toggle):
     """
-    Create an alternate path into the Boggy Swamp Ambush. Enabling this setting may require Jak to get Flut Flut
-    into the ambush arena instead of using attacking moves. This only applies if "Enable Move Randomizer"
-    is ON.
+    Create an alternate path into the Boggy Swamp Ambush.
+
+    Enabling this setting may require Jak to get Flut Flut into the ambush arena instead of using attacking moves.
+
+    This only applies if "Enable Move Randomizer" is ON.
     """
     display_name = "Boggy Swamp Flut Flut Escape"
 
 
 class SnowyMountainFlutFlutEscape(Toggle):
     """
-    Changes Snowy Mountain to rely on Flut Flut for movement. Enabling this setting may require Jak to get Flut Flut
-    over an invisible barrier to access all of Snowy Mountain.
+    Changes Snowy Mountain to rely on Flut Flut for movement.
+
+    Enabling this setting may require Jak to get Flut Flut over an invisible barrier to access all of Snowy Mountain.
     """
     display_name = "Snowy Mountain Flut Flut Escape"
 
 
 class SnowyMountainFlutFlutSkip(Toggle):
     """
-    Create an alternative path to the end of the Flut Flut course in Snowy Mountain. Enabling this setting may require
-    Jak to use advanced movement tricks to reach the Fort Gate Button with only Single Jump and no Flut Flut.
+    Create an alternative path to the end of the Flut Flut course in Snowy Mountain.
+
+    Enabling this setting may require Jak to use advanced movement tricks to reach the Fort Gate Button with only
+    *Single Jump* and no *Flut Flut*.
     """
     display_name = "Snowy Mountain Flut Flut Skip"
 
 
 class SandoverVillageCliffOrbCacheClimb(Toggle):
     """
-    Create an alternative path to the Sandover Village orb cache on the cliff. Enabling this setting may require Jak to
-    use precise jumps to reach the orb cache (and the blue eco next to it) with only Single Jump.
+    Create an alternative path to the Sandover Village orb cache on the cliff.
+
+    Enabling this setting may require Jak to use precise jumps to reach the orb cache (and the blue eco next to it) with
+    only *Single Jump*.
+
     This only applies if "Enable Move Randomizer" is ON.
     """
     display_name = "Sandover Village Orb Cache Climb"
@@ -407,8 +440,10 @@ class SandoverVillageCliffOrbCacheClimb(Toggle):
 
 class AttacklessLurkerCannons(Toggle):
     """
-    Remove the attack requirement for lurker cannon power cells in Sentinel Beach and Misty Island. Enabling this
-    setting may require Jak to defeat the lurkers next to the cannon without any attacking moves.
+    Remove the attack requirement for lurker cannon power cells in Sentinel Beach and Misty Island.
+
+    Enabling this setting may require Jak to defeat the lurkers next to the cannon without any attacking moves.
+
     This only applies if "Enable Move Randomizer" is ON.
     """
     display_name = "Attackless Lurker Cannons"
@@ -416,8 +451,10 @@ class AttacklessLurkerCannons(Toggle):
 
 class SentinelBeachAttacklessPelican(Toggle):
     """
-    Create an alternative path to the Pelican power cell in Sentinel Beach. Enabling this setting may require Jak to
-    use other unlocks to acquire the power cell without any attacking moves.
+    Create an alternative path to the Pelican power cell in Sentinel Beach.
+
+    Enabling this setting may require Jak to  use other unlocks to acquire the power cell without any attacking moves.
+
     This only applies if "Enable Move Randomizer" is ON.
     """
     display_name = "Sentinel Beach Attackless Pelican"
@@ -425,32 +462,42 @@ class SentinelBeachAttacklessPelican(Toggle):
 
 class AttackWithRollJump(Toggle):
     """
-    Treat Roll Jump as a valid attack move for some power cells. Enabling this setting may require Jak to use Roll Jump
-    to destroy objects to acquire these power cells. This only applies if "Enable Move Randomizer" is ON.
+    Treat *Roll Jump* as a valid attack move for some power cells.
+
+    Enabling this setting may require Jak to use *Roll Jump* to destroy objects and acquire these power cells.
+
+    This only applies if "Enable Move Randomizer" is ON.
     """
     display_name = "Attack with Roll Jump"
 
 
 class ForbiddenJungleAttacklessSpiralStumpsScoutFly(Toggle):
     """
-    Create an alternative path to the Scout Fly "On Spiral Of Stumps" in Forbidden Jungle. Enabling this setting may
-    require Jak to collect this scout fly without attack moves. This only applies if "Enable Move Randomizer" is ON.
+    Create an alternative path to the Scout Fly "On Spiral Of Stumps" in Forbidden Jungle.
+
+    Enabling this setting may require Jak to use precise movement to collect this scout fly without attack moves.
+
+    This only applies if "Enable Move Randomizer" is ON.
     """
     display_name = "Forbidden Jungle Attackless Spiral Stumps Scout Fly"
 
 
 class ForbiddenJungleElevatorSkip(Toggle):
     """
-    Create an alternative path to the temple interior in Forbidden Jungle. Enabling this setting may require Jak to
-    get inside the temple with only Jump Kick (without having the Jungle Elevator unlocked).
+    Create an alternative path to the temple interior in Forbidden Jungle without having *Jungle Elevator* unlocked.
+
+    Enabling this setting may require Jak to get inside the temple with only *Jump Kick*.
     """
     display_name = "Forbidden Jungle Elevator Skip"
 
 
 class MistyIslandEarlyFarSideOrbCache(Toggle):
     """
-    Create an alternative path to the Far Side Orb Cache in Misty Island. Enabling this setting may require Jak to
-    reach the orb cache with blue eco with only Single Jump. This only applies if "Enable Move Randomizer" is ON.
+    Create an alternative path to the Far Side Orb Cache in Misty Island.
+
+    Enabling this setting may require Jak to reach the orb cache with blue eco with only *Single Jump*.
+
+    This only applies if "Enable Move Randomizer" is ON.
     """
     display_name = "Misty Island Early Far Side Orb Cache"
 
@@ -458,8 +505,11 @@ class MistyIslandEarlyFarSideOrbCache(Toggle):
 class MistyIslandAttacklessScoutFlies(Toggle):
     """
     Remove attack requirements to the scout flies "Barrel Ramps", "Ledge Near Arena Entrance", "Near Arena Door",
-    "Overlooking Entrance" in Misty Island. Enabling this setting may require Jak to break these scout fly boxes with
-    precise blue eco movement or clever use of game mechanics.
+    "Overlooking Entrance" in Misty Island.
+
+    Enabling this setting may require Jak to break these scout fly boxes with precise blue eco movement or clever use
+    of game mechanics.
+
     This only applies if "Enable Move Randomizer" is ON.
     """
     display_name = "Misty Island Attackless Scout Flies"
@@ -467,8 +517,11 @@ class MistyIslandAttacklessScoutFlies(Toggle):
 
 class MistyIslandArenaFightSkip(Toggle):
     """
-    Create an alternative path to the power cell "Return To The Dark Eco Pool" in Misty Island. Enabling this setting
-    may require Jak to reach this power cell with only Single Jump. This only applies if "Enable Move Randomizer" is ON.
+    Create an alternative path to the power cell "Return To The Dark Eco Pool" in Misty Island.
+
+    Enabling this setting may require Jak to reach this power cell with only *Single Jump*.
+
+    This only applies if "Enable Move Randomizer" is ON.
     """
     display_name = "Misty Island Arena Fight Skip"
 
@@ -476,24 +529,34 @@ class MistyIslandArenaFightSkip(Toggle):
 class MistyIslandFarSideCliffSeesawSkip(Toggle):
     """
     Create an alternative path to the far side cliff (with scout fly "Scout Fly On Ledge Near Arena Exit") in Misty
-    Island. Enabling this setting may require Jak to use uneven terrain to find an alternative way to the cliff, using
-    only Single Jump. This only applies if "Enable Move Randomizer" is ON.
+    Island.
+
+    Enabling this setting may require Jak to use uneven terrain to find an alternative way to the cliff, using
+    only *Single Jump*.
+
+    This only applies if "Enable Move Randomizer" is ON.
     """
     display_name = "Misty Island Far Side Cliff Seesaw Skip"
 
 
 class RockVillageEarlyOrbCache(Toggle):
     """
-    Remove requirements from the orb cache in Rock Village. Enabling this setting may require Jak to use precise
-    movement to reach the orb cache with only Single Jump. This only applies if "Enable Move Randomizer" is ON.
+    Remove requirements from the orb cache in Rock Village.
+
+    Enabling this setting may require Jak to use precise movement to reach the orb cache with only *Single Jump*.
+
+    This only applies if "Enable Move Randomizer" is ON.
     """
     display_name = "Rock Village Early Orb Cache"
 
 
 class RockVillagePontoonSkip(Toggle):
     """
-    Create alternative paths to Boggy Swamp and Klaww Cliff in Rock Village. Enabling this setting may require Jak to
-    use precise movement to reach these locations without having the Warrior's Pontoons unlocked.
+    Create alternative paths to Boggy Swamp and Klaww Cliff in Rock Village.
+
+    Enabling this setting may require Jak to use precise movement to reach these locations without having the
+    *Warrior's Pontoons* unlocked.
+
     This only applies if "Enable Move Randomizer" is ON.
     """
     display_name = "Rock Village Pontoon Skip"
@@ -501,26 +564,35 @@ class RockVillagePontoonSkip(Toggle):
 
 class KlawwCliffClimb(Toggle):
     """
-    Create an alternative path to get up to Klaww from Rock Village. Enabling this setting may require Jak to use
-    glitches and uneven terrain to reach Klaww with only Single Jump. This only applies if "Enable Move Randomizer" is
-    ON.
+    Create an alternative path to get up to Klaww from Rock Village.
+
+    Enabling this setting may require Jak to use glitches and uneven terrain to reach Klaww with only *Single Jump*.
+
+    This only applies if "Enable Move Randomizer" is ON.
     """
     display_name = "Klaww Cliff Climb"
 
 
 class KlawwBoulderSkip(Toggle):
     """
-    Create an alternative path to Klaww without having enough power cells. Enabling this setting may require
-    Jak to use glitches to reach Klaww even if the boulder is not lifted. This may drastically increase the amount of
-    reachable locations when Rock Village is reachable. This only applies if "Enable Move Randomizer" is ON.
+    Create an alternative path to Klaww without having enough power cells.
+
+    Enabling this setting may require Jak to use glitches to reach Klaww even if the boulder is not lifted.
+
+    This may drastically increase the amount of reachable locations when Rock Village is reachable.
+
+    This only applies if "Enable Move Randomizer" is ON.
     """
     display_name = "Klaww Boulder Skip"
 
 
 class BoggySwampPreciseMovement(Toggle):
     """
-    Create an alternative path through Boggy Swamp. Enabling this setting may require Jak to traverse through the
-    whole Boggy Swamp with only Single Jump using precise movement, invincibility after taking damage, and respawns.
+    Create an alternative path through Boggy Swamp.
+
+    Enabling this setting may require Jak to traverse through the whole Boggy Swamp with only *Single Jump* using
+    precise movement, invincibility after taking damage, and respawns.
+
     This only applies if "Enable Move Randomizer" is ON.
     """
     display_name = "Boggy Swamp Precise Movement"
@@ -528,25 +600,32 @@ class BoggySwampPreciseMovement(Toggle):
 
 class BoggySwampAttacklessAmbush(Toggle):
     """
-    Remove the attack requirement from the Boggy Swamp ambush. Enabling this setting may require Jak to shoot yellow Eco
-    through his goggles to defeat the lurkers. This only applies if "Enable Move Randomizer" is ON.
+    Remove the attack requirement from the Boggy Swamp ambush.
+
+    Enabling this setting may require Jak to defeat the lurkers by only shooting yellow Eco through his goggles.
+
+    This only applies if "Enable Move Randomizer" is ON.
     """
     display_name = "Boggy Swamp Attackless Ambush"
 
 
 class BoggySwampFlutFlutSkip(Toggle):
     """
-    Create an alternative path to the Flut Flut course without having Flut Flut unlocked. Enabling this setting may
-    require Jak to complete the whole course with only Roll and Roll Jump.
+    Create an alternative path through the Flut Flut course in Boggy Swamp without having *Flut Flut* unlocked.
+
+    Enabling this setting may require Jak to complete the whole course with only *Roll Jump*.
     """
     display_name = "Boggy Swamp Flut Flut Skip"
 
 
 class LostPrecursorCitySingleJumpSlideTubeClimb(Toggle):
     """
-    Create an alternative path through the helix with the rising dark eco in Lost Precursor City. Enabling this setting
-    may require Jak to use precise movement to reach the power cell at the bottom of Lost Precursor City and escape the
-    rising dark eco with only Single Jump. This only applies if "Enable Move Randomizer" is ON.
+    Create an alternative path through the helix with the rising dark eco in Lost Precursor City.
+
+    Enabling this setting may require Jak to use precise movement to reach the power cell at the bottom of Lost
+    Precursor City and escape the rising dark eco with only *Single Jump*.
+
+    This only applies if "Enable Move Randomizer" is ON.
     """
     display_name = "Lost Precursor City Single Jump Slide Tube Climb"
 

--- a/worlds/jakanddaxter/options.py
+++ b/worlds/jakanddaxter/options.py
@@ -391,7 +391,7 @@ class SnowyMountainFlutFlutEscape(Toggle):
 class SnowyMountainFlutFlutSkip(Toggle):
     """
     Create an alternative path to the end of the Flut Flut course in Snowy Mountain. Enabling this setting may require
-    Jak to use advanced movement tricks to reach the end of the Flut Flut course with only Single Jump and no Flut Flut.
+    Jak to use advanced movement tricks to reach the Fort Gate Button with only Single Jump and no Flut Flut.
     """
     display_name = "Snowy Mountain Flut Flut Skip"
 

--- a/worlds/jakanddaxter/regions.py
+++ b/worlds/jakanddaxter/regions.py
@@ -78,11 +78,7 @@ def create_regions(world: "JakAndDaxterWorld"):
     mp, mpr = mountain_pass.build_regions("Mountain Pass", world)
     vc = volcanic_crater.build_regions("Volcanic Crater", world)
     sc = spider_cave.build_regions("Spider Cave", world)
-
-    if options.snowy_mountain_flut_flut_escape:
-        sm = snowy_mountain.build_regions_with_flut_flut("Snowy Mountain", world)
-    else:
-        sm = snowy_mountain.build_regions("Snowy Mountain", world)
+    sm = snowy_mountain.build_regions("Snowy Mountain", world)
 
     lt = lava_tube.build_regions("Lava Tube", world)
     gmc, fb, fd = gol_and_maias_citadel.build_regions("Gol and Maia's Citadel", world)

--- a/worlds/jakanddaxter/regs/gol_and_maias_citadel_regions.py
+++ b/worlds/jakanddaxter/regs/gol_and_maias_citadel_regions.py
@@ -19,11 +19,11 @@ def build_regions(level_name: str, world: "JakAndDaxterWorld") -> tuple[JakAndDa
     if options.boosted_and_extended_uppercuts:
         def can_jump_farther(state: CollectionState, p: int) -> bool:
             return (state.has_any(("Double Jump", "Jump Kick"), p)
+                    or state.has_all(("Punch", "Punch Uppercut"), p)
                     or state.has_all(("Roll", "Roll Jump"), p))
     else:
         def can_jump_farther(state: CollectionState, p: int) -> bool:
             return (state.has_any(("Double Jump", "Jump Kick"), p)
-                    or state.has_all(("Punch", "Punch Uppercut"), p)
                     or state.has_all(("Roll", "Roll Jump"), p))
 
     def can_jump_stairs(state: CollectionState, p: int) -> bool:

--- a/worlds/jakanddaxter/regs/misty_island_regions.py
+++ b/worlds/jakanddaxter/regs/misty_island_regions.py
@@ -37,11 +37,8 @@ def build_regions(level_name: str, world: "JakAndDaxterWorld") -> JakAndDaxterRe
 
     # To carry the blue eco fast enough to open this cache, you need to break the bone bridges along the way.
     far_side_cache = JakAndDaxterRegion("Far Side Orb Cache", player, multiworld, level_name, 15)
-    if options.misty_island_early_far_side_orb_cache:
-        # It's possible to reach the orb cache without any attacks.
-        far_side_cache.add_cache_locations([11072])
-    else:
-        far_side_cache.add_cache_locations([11072], access_rule=lambda state: can_fight(state, player))
+    # All rules are already needed to reach the cache region (with the orbs in them).
+    far_side_cache.add_cache_locations([11072])
 
     barrel_course = JakAndDaxterRegion("Barrel Course", player, multiworld, level_name, 10)
     if options.misty_island_attackless_scout_flies:
@@ -101,8 +98,12 @@ def build_regions(level_name: str, world: "JakAndDaxterWorld") -> JakAndDaxterRe
                      state.has("Jump Dive", player)
                      or state.has_all(("Crouch", "Crouch Jump"), player))
 
-    # Only if you can break the bone bridges to carry blue eco over the mud pit.
-    far_side.connect(far_side_cache, rule=lambda state: can_fight(state, player))
+    if options.misty_island_early_far_side_orb_cache:
+        # Only if you can break the bone bridges to carry blue eco over the mud pit.
+        far_side.connect(far_side_cache, rule=lambda state: can_fight(state, player))
+    else:
+        # It's possible to reach the orb cache without any attacks.
+        far_side.connect(far_side_cache)
 
     far_side_cliff.connect(far_side)           # Run and jump down.
 

--- a/worlds/jakanddaxter/regs/sentinel_beach_regions.py
+++ b/worlds/jakanddaxter/regs/sentinel_beach_regions.py
@@ -100,7 +100,7 @@ def build_regions(level_name: str, world: "JakAndDaxterWorld") -> JakAndDaxterRe
     rock_spires.connect(cannon_tower)
 
     # An advanced way of reaching the cannon tower without Blue Eco Switch.
-    if options.sentinel_beach_cannon_tower_climb != SentinelBeachCannonTowerClimb.option_off:
+    if options.sentinel_beach_cannon_tower_climb != SentinelBeachCannonTowerClimb.option_no:
         main_area.connect(cannon_tower, rule=lambda state: can_climb_cannon_tower(state, player))
 
     # All these can go back to main_area immediately.

--- a/worlds/jakanddaxter/regs/snowy_mountain_regions.py
+++ b/worlds/jakanddaxter/regs/snowy_mountain_regions.py
@@ -1,6 +1,6 @@
 from BaseClasses import CollectionState
 from .region_base import JakAndDaxterRegion
-from ..options import EnableOrbsanity
+from ..options import EnableOrbsanity, SnowyMountainEntranceClimb
 from typing import TYPE_CHECKING
 if TYPE_CHECKING:
     from .. import JakAndDaxterWorld
@@ -8,17 +8,51 @@ from ..rules import can_fight, can_reach_orbs_level
 
 
 # God help me... here we go.
-# ALL OF SNOWY is affected heavily by the value of Flut Flut escape.
-# So below this function, we will be defining an entirely different function with Flut Flut access rules.
 def build_regions(level_name: str, world: "JakAndDaxterWorld") -> JakAndDaxterRegion:
     multiworld = world.multiworld
     options = world.options
     player = world.player
 
-    # We need a few helper functions.
-    def can_cross_long_gap(state: CollectionState, p: int) -> bool:
-        return (state.has_all(("Roll", "Roll Jump"), p)
-                or state.has_all(("Double Jump", "Jump Kick"), p))
+    # First, define helper functions to determine if Jak can actually get anywhere.
+    if options.boosted_and_extended_uppercuts:
+        def can_do_boosted(state: CollectionState, p: int) -> bool:
+            return state.has_all(("Punch", "Punch Uppercut"), p)
+    else:
+        def can_do_boosted(_: CollectionState, __: int) -> bool:
+            return False
+
+    if options.snowy_mountain_entrance_climb == SnowyMountainEntranceClimb.option_hard:
+        # Single Jump is enough to slide on the left ledge by getting attacked while jumping next to it.
+        def can_cross_first_gap(_: CollectionState, __: int) -> bool:
+            return True
+    elif options.snowy_mountain_entrance_climb == SnowyMountainEntranceClimb.option_medium:
+        # Double Jump or Crouch Jump to slide on the left ledge.
+        def can_cross_first_gap(state: CollectionState, p: int) -> bool:
+            return (state.has("Double Jump", p)
+                    or state.has_all(("Crouch", "Crouch Jump"), p)
+                    or state.has_all(("Roll", "Roll Jump"), p)
+                    or state.has_all(("Double Jump", "Jump Kick"), p)
+                    or can_do_boosted(state, p))
+    else:
+        # Cross the gap by jumping over it.
+        def can_cross_first_gap(state: CollectionState, p: int) -> bool:
+            return (state.has_all(("Roll", "Roll Jump"), p)
+                    or state.has_all(("Double Jump", "Jump Kick"), p)
+                    or can_do_boosted(state, p))
+
+    # Helper function that returns true if Jak can reach and free Flut Flut.
+    # When Flut Flut can be reached, it can reach everything in the whole level.
+    if options.snowy_mountain_flut_flut_escape:
+        def can_free_flut_flut(state: CollectionState, p: int) -> bool:
+            return can_cross_first_gap(state, p)
+    else:
+        def can_free_flut_flut(_: CollectionState, __: int) -> bool:
+            return False
+
+    def can_cross_medium_gap(state: CollectionState, p: int) -> bool:
+        return (state.has_any(("Double Jump", "Jump Kick"), p)
+                or state.has_all(("Roll", "Roll Jump"), p)
+                or can_do_boosted(state, p))
 
     def can_jump_blockers(state: CollectionState, p: int) -> bool:
         return (state.has_any(("Double Jump", "Jump Kick"), p)
@@ -26,7 +60,8 @@ def build_regions(level_name: str, world: "JakAndDaxterWorld") -> JakAndDaxterRe
                 or state.has_all(("Punch", "Punch Uppercut"), p))
 
     main_area = JakAndDaxterRegion("Main Area", player, multiworld, level_name, 0)
-    main_area.add_fly_locations([65], access_rule=lambda state: world.can_free_scout_flies(state, player))
+    main_area.add_fly_locations([65], access_rule=lambda state:
+                                world.can_free_scout_flies(state, player) or can_free_flut_flut(state, player))
 
     # We need a few virtual regions like we had for Dark Crystals in Spider Cave.
     # First, a virtual region for the glacier lurkers.
@@ -37,8 +72,7 @@ def build_regions(level_name: str, world: "JakAndDaxterWorld") -> JakAndDaxterRe
     # Troop in ice_skating_rink: cross main_area and fort_exterior.
     # Troop in fort_exterior: cross main_area and fort_exterior.
     glacier_lurkers.add_cell_locations([61], access_rule=lambda state:
-                                       can_fight(state, player)
-                                       and can_cross_long_gap(state, player))
+                                       can_fight(state, player) or can_free_flut_flut(state, player))
 
     # Second, a virtual region for the precursor blockers. Unlike the others, this contains orbs:
     # the total number of orbs that sit on top of the blockers. Yes, there are only 8.
@@ -49,9 +83,9 @@ def build_regions(level_name: str, world: "JakAndDaxterWorld") -> JakAndDaxterRe
     # 4 in ice_skating_rink
     # 3 in fort_exterior
     # 3 in bunny_cave_start
-    blockers.add_cell_locations([66], access_rule=lambda state:
-                                can_fight(state, player)
-                                and can_cross_long_gap(state, player))
+    # Jak can only reach the blockers virtual location if he can jump on top of the blockers,
+    # the power cell has no additional requirements.
+    blockers.add_cell_locations([66])
 
     snowball_canyon = JakAndDaxterRegion("Snowball Canyon", player, multiworld, level_name, 28)
 
@@ -59,25 +93,32 @@ def build_regions(level_name: str, world: "JakAndDaxterWorld") -> JakAndDaxterRe
     frozen_box_cave = JakAndDaxterRegion("Frozen Box Cave", player, multiworld, level_name, 12)
     frozen_box_cave.add_fly_locations([327745], access_rule=lambda state:
                                       state.has("Yellow Eco Switch", player)
-                                      or world.can_free_scout_flies(state, player))
+                                      or world.can_free_scout_flies(state, player)
+                                      or can_free_flut_flut(state, player))
 
-    # This region has crates that can *only* be broken with YES.
+    # This region has crates that can *only* be broken with YES or by Flut Flut.
     frozen_box_cave_crates = JakAndDaxterRegion("Frozen Box Cave Orb Crates", player, multiworld, level_name, 8)
-    frozen_box_cave_crates.add_cell_locations([67], access_rule=lambda state:
-                                              state.has("Yellow Eco Switch", player))
+    # No additional rules are required here since Jak can only reach this region if he can break the boxes.
+    frozen_box_cave_crates.add_cell_locations([67])
 
     # Include 6 orbs on the twin elevator ice ramp.
     ice_skating_rink = JakAndDaxterRegion("Ice Skating Rink", player, multiworld, level_name, 20)
-    ice_skating_rink.add_fly_locations([131137], access_rule=lambda state: world.can_free_scout_flies(state, player))
+    ice_skating_rink.add_fly_locations([131137], access_rule=lambda state:
+                                       world.can_free_scout_flies(state, player) or can_free_flut_flut(state, player))
 
+    # Flut Flut Course, only reachable when Flut Flut is unlocked.
     flut_flut_course = JakAndDaxterRegion("Flut Flut Course", player, multiworld, level_name, 15)
-    flut_flut_course.add_cell_locations([63], access_rule=lambda state: state.has("Flut Flut", player))
-    flut_flut_course.add_special_locations([63], access_rule=lambda state: state.has("Flut Flut", player))
+
+    # Flut Flut course finish may be reached early with advanced movement, without collecting orbs on the course.
+    flut_flut_course_finish = JakAndDaxterRegion("Flut Flut Course Finish", player, multiworld, level_name, 0)
+    flut_flut_course_finish.add_cell_locations([63])
+    flut_flut_course_finish.add_special_locations([63])
 
     # Includes the bridge from snowball_canyon, the area beneath that bridge, and the areas around the fort.
     fort_exterior = JakAndDaxterRegion("Fort Exterior", player, multiworld, level_name, 20)
     fort_exterior.add_fly_locations([65601, 393281], access_rule=lambda state:
-                                    world.can_free_scout_flies(state, player))
+                                    world.can_free_scout_flies(state, player)
+                                    or can_free_flut_flut(state, player))
 
     # Includes the icy island and bridge outside the cave entrance.
     bunny_cave_start = JakAndDaxterRegion("Bunny Cave (Start)", player, multiworld, level_name, 10)
@@ -101,285 +142,83 @@ def build_regions(level_name: str, world: "JakAndDaxterWorld") -> JakAndDaxterRe
     # Need higher jump.
     fort_interior_base = JakAndDaxterRegion("Fort Interior (Base)", player, multiworld, level_name, 0)
     fort_interior_base.add_fly_locations([262209], access_rule=lambda state:
-                                         world.can_free_scout_flies(state, player))
+                                         world.can_free_scout_flies(state, player)
+                                         or can_free_flut_flut(state, player))
 
     # Need farther jump.
     fort_interior_course_end = JakAndDaxterRegion("Fort Interior (Course End)", player, multiworld, level_name, 2)
     fort_interior_course_end.add_cell_locations([62])
 
-    # Wire up the virtual regions first.
-    main_area.connect(blockers, rule=lambda state: can_jump_blockers(state, player))
-    main_area.connect(glacier_lurkers, rule=lambda state: can_fight(state, player))
 
-    # Yes, the only (other) way into the rest of the level requires advanced movement.
-    main_area.connect(snowball_canyon, rule=lambda state: can_cross_long_gap(state, player))
+    # Yes, the only way into the rest of the level may require advanced movement.
+    main_area.connect(snowball_canyon, rule=lambda state: can_cross_first_gap(state, player))
+
+    # Wire up the virtual regions first.
+    # There are orbs on the blockers that can only be reached if Jak can jump on them.
+    snowball_canyon.connect(blockers, rule=lambda state:
+                            can_jump_blockers(state, player) or can_free_flut_flut(state, player))
+    # All lurkers can be reached once Jak can reach Snowball Canyon.
+    snowball_canyon.connect(glacier_lurkers)
+
 
     snowball_canyon.connect(main_area)                              # But you can just jump down and run up the ramp.
     snowball_canyon.connect(bunny_cave_start)                       # Jump down from the glacier troop cliff.
     snowball_canyon.connect(fort_exterior)                          # Jump down, to the left of frozen box cave.
     snowball_canyon.connect(frozen_box_cave, rule=lambda state:     # More advanced movement.
-                            can_cross_long_gap(state, player))
+                            can_cross_medium_gap(state, player)
+                            or can_free_flut_flut(state, player))
 
     frozen_box_cave.connect(snowball_canyon, rule=lambda state:                 # Same movement to go back.
-                            can_cross_long_gap(state, player))
+                            can_cross_medium_gap(state, player)
+                            or can_free_flut_flut(state, player))
     frozen_box_cave.connect(frozen_box_cave_crates, rule=lambda state:          # YES to get these crates.
-                            state.has("Yellow Eco Switch", player))
+                            state.has("Yellow Eco Switch", player)              # Flut Flut can break boxes as well.
+                            or can_free_flut_flut(state, player))
     frozen_box_cave.connect(ice_skating_rink, rule=lambda state:                # Same movement to go forward.
-                            can_cross_long_gap(state, player))
+                            can_cross_medium_gap(state, player)
+                            or can_free_flut_flut(state, player))
 
     frozen_box_cave_crates.connect(frozen_box_cave)                             # Semi-virtual region, no moves req'd.
 
     ice_skating_rink.connect(frozen_box_cave, rule=lambda state:                # Same movement to go back.
-                             can_cross_long_gap(state, player))
+                             can_cross_medium_gap(state, player)
+                             or can_free_flut_flut(state, player))
     ice_skating_rink.connect(flut_flut_course, rule=lambda state:               # Duh.
                              state.has("Flut Flut", player))
     ice_skating_rink.connect(fort_exterior)                                     # Just slide down the elevator ramp.
 
-    fort_exterior.connect(ice_skating_rink, rule=lambda state:                  # Twin elevators OR scout fly ledge.
-                          can_cross_long_gap(state, player))                    # Both doable with main_gap logic.
+    fort_exterior.connect(ice_skating_rink)                                     # Twin elevators OR scout fly ledge
+                                                                                # Elevators can be done with Single Jump
     fort_exterior.connect(snowball_canyon)                                      # Run across bridge.
     fort_exterior.connect(fort_interior, rule=lambda state:                     # Duh.
                           state.has("Snowy Fort Gate", player))
     fort_exterior.connect(bunny_cave_start)                                     # Run across bridge.
     fort_exterior.connect(switch_cave, rule=lambda state:                       # Yes, blocker jumps work here.
-                          can_jump_blockers(state, player))
+                          can_jump_blockers(state, player)
+                          or can_free_flut_flut(state, player))
+
+    if options.snowy_mountain_flut_flut_skip:
+        fort_exterior.connect(flut_flut_course_finish)                          # Zoom walk down.
 
     fort_interior.connect(fort_interior_caches, rule=lambda state:              # Just need a little height.
                           state.has("Double Jump", player)
-                          or state.has_all(("Crouch", "Crouch Jump"), player))
+                          or state.has_all(("Crouch", "Crouch Jump"), player)
+                          or can_free_flut_flut(state, player))
     fort_interior.connect(fort_interior_base, rule=lambda state:                # Just need a little height.
                           state.has("Double Jump", player)
-                          or state.has_all(("Crouch", "Crouch Jump"), player))
+                          or state.has_all(("Crouch", "Crouch Jump"), player)
+                          or can_free_flut_flut(state, player))
     fort_interior.connect(fort_interior_course_end, rule=lambda state:          # Just need a little distance.
                           state.has_any(("Double Jump", "Jump Kick"), player)
-                          or state.has_all(("Punch", "Punch Uppercut"), player))
+                          or state.has_all(("Punch", "Punch Uppercut"), player)
+                          or can_free_flut_flut(state, player))
 
-    flut_flut_course.connect(fort_exterior)                                     # Ride the elevator.
-
-    # Must fight way through cave, but there is also a grab-less ledge we must jump over.
-    bunny_cave_start.connect(bunny_cave_end, rule=lambda state:
-                             can_fight(state, player)
-                             and (state.has("Double Jump", player)
-                                  or state.has_all(("Crouch", "Crouch Jump"), player)))
-
-    # All jump down.
-    fort_interior_caches.connect(fort_interior)
-    fort_interior_base.connect(fort_interior)
-    fort_interior_course_end.connect(fort_interior)
-    switch_cave.connect(fort_exterior)
-    bunny_cave_end.connect(fort_exterior)
-
-    # I really hope that is everything.
-    world.level_to_regions[level_name].append(main_area)
-    world.level_to_regions[level_name].append(glacier_lurkers)
-    world.level_to_regions[level_name].append(blockers)
-    world.level_to_regions[level_name].append(snowball_canyon)
-    world.level_to_regions[level_name].append(frozen_box_cave)
-    world.level_to_regions[level_name].append(frozen_box_cave_crates)
-    world.level_to_regions[level_name].append(ice_skating_rink)
-    world.level_to_regions[level_name].append(flut_flut_course)
-    world.level_to_regions[level_name].append(fort_exterior)
-    world.level_to_regions[level_name].append(bunny_cave_start)
-    world.level_to_regions[level_name].append(bunny_cave_end)
-    world.level_to_regions[level_name].append(switch_cave)
-    world.level_to_regions[level_name].append(fort_interior)
-    world.level_to_regions[level_name].append(fort_interior_caches)
-    world.level_to_regions[level_name].append(fort_interior_base)
-    world.level_to_regions[level_name].append(fort_interior_course_end)
-
-    # Yes, this is a bit nutty, but this allows us to create alternate ways into SM
-    # without having to change the rest of the regions.
-    if options.snowy_mountain_entrance_climb:
-        slippery_rock = JakAndDaxterRegion("Slippery Rock", player, multiworld, level_name, 0)
-        main_area.connect(slippery_rock, rule=lambda state:
-                          state.has("Double Jump", player)
-                          or state.has_all(("Crouch", "Crouch Jump"), player))
-        slippery_rock.connect(snowball_canyon)
-        world.level_to_regions[level_name].append(slippery_rock)
-
-    if options.boosted_and_extended_uppercuts:
-        boosted_gap = JakAndDaxterRegion("Boosted Gap", player, multiworld, level_name, 0)
-        main_area.connect(boosted_gap, rule=lambda state: state.has_all(("Punch", "Punch Uppercut"), player))
-        boosted_gap.connect(snowball_canyon)
-        world.level_to_regions[level_name].append(boosted_gap)
-
-    # If Per-Level Orbsanity is enabled, build the special Orbsanity Region. This is a virtual region always
-    # accessible to Main Area. The Locations within are automatically checked when you collect enough orbs.
-    if options.enable_orbsanity == EnableOrbsanity.option_per_level:
-        orbs = JakAndDaxterRegion("Orbsanity", player, multiworld, level_name)
-
-        bundle_count = 200 // world.orb_bundle_size
-        for bundle_index in range(bundle_count):
-            amount = world.orb_bundle_size * (bundle_index + 1)
-            orbs.add_orb_locations(12,
-                                   bundle_index,
-                                   access_rule=lambda state, level=level_name, orb_amount=amount:
-                                   can_reach_orbs_level(state, player, world, level, orb_amount))
-        multiworld.regions.append(orbs)
-        main_area.connect(orbs)
-
-    return main_area
-
-
-def build_regions_with_flut_flut(level_name: str, world: "JakAndDaxterWorld") -> JakAndDaxterRegion:
-    multiworld = world.multiworld
-    options = world.options
-    player = world.player
-
-    # We need a few helper functions.
-    def can_cross_long_gap(state: CollectionState, p: int) -> bool:
-        return (state.has_all(("Roll", "Roll Jump"), p)
-                or state.has_all(("Double Jump", "Jump Kick"), p))
-
-    def can_jump_blockers(state: CollectionState, p: int) -> bool:
-        return (state.has_any(("Double Jump", "Jump Kick"), p)
-                or state.has_all(("Crouch", "Crouch Jump"), p)
-                or state.has_all(("Punch", "Punch Uppercut"), p))
-
-    main_area = JakAndDaxterRegion("Main Area", player, multiworld, level_name, 0)
-    main_area.add_fly_locations([65], access_rule=lambda state: world.can_free_scout_flies(state, player))
-
-    # We need a few virtual regions like we had for Dark Crystals in Spider Cave.
-    # First, a virtual region for the glacier lurkers.
-    glacier_lurkers = JakAndDaxterRegion("Glacier Lurkers", player, multiworld, level_name, 0)
-
-    # Need to fight all the troops.
-    # Troop in snowball_canyon: cross main_area.
-    # Troop in ice_skating_rink: cross main_area and fort_exterior.
-    # Troop in fort_exterior: cross main_area and fort_exterior.
-    glacier_lurkers.add_cell_locations([61], access_rule=lambda state:
-                                       can_cross_long_gap(state, player)
-                                       and (state.has("Flut Flut", player) or can_fight(state, player)))
-
-    # Second, a virtual region for the precursor blockers. Unlike the others, this contains orbs:
-    # the total number of orbs that sit on top of the blockers. Yes, there are only 8.
-    blockers = JakAndDaxterRegion("Precursor Blockers", player, multiworld, level_name, 8)
-
-    # 1 in main_area
-    # 2 in snowball_canyon
-    # 4 in ice_skating_rink
-    # 3 in fort_exterior
-    # 3 in bunny_cave_start
-    blockers.add_cell_locations([66], access_rule=lambda state:
-                                can_cross_long_gap(state, player)
-                                and (state.has("Flut Flut", player) or can_fight(state, player)))
-
-    snowball_canyon = JakAndDaxterRegion("Snowball Canyon", player, multiworld, level_name, 28)
-
-    # The scout fly box *can* be broken without YES, so leave it in this region.
-    frozen_box_cave = JakAndDaxterRegion("Frozen Box Cave", player, multiworld, level_name, 12)
-    frozen_box_cave.add_fly_locations([327745], access_rule=lambda state:
-                                      state.has_any(("Flut Flut", "Yellow Eco Switch"), player)
-                                      or world.can_free_scout_flies(state, player))
-
-    # This region has crates that can *only* be broken with YES.
-    frozen_box_cave_crates = JakAndDaxterRegion("Frozen Box Cave Orb Crates", player, multiworld, level_name, 8)
-    frozen_box_cave_crates.add_cell_locations([67], access_rule=lambda state:
-                                              state.has_any(("Flut Flut", "Yellow Eco Switch"), player))
-
-    # Include 6 orbs on the twin elevator ice ramp.
-    ice_skating_rink = JakAndDaxterRegion("Ice Skating Rink", player, multiworld, level_name, 20)
-    ice_skating_rink.add_fly_locations([131137], access_rule=lambda state: world.can_free_scout_flies(state, player))
-
-    flut_flut_course = JakAndDaxterRegion("Flut Flut Course", player, multiworld, level_name, 15)
-    flut_flut_course.add_cell_locations([63], access_rule=lambda state: state.has("Flut Flut", player))
-    flut_flut_course.add_special_locations([63], access_rule=lambda state: state.has("Flut Flut", player))
-
-    # Includes the bridge from snowball_canyon, the area beneath that bridge, and the areas around the fort.
-    fort_exterior = JakAndDaxterRegion("Fort Exterior", player, multiworld, level_name, 20)
-    fort_exterior.add_fly_locations([65601, 393281], access_rule=lambda state:
-                                    state.has("Flut Flut", player)
-                                    or world.can_free_scout_flies(state, player))
-
-    # Includes the icy island and bridge outside the cave entrance.
-    bunny_cave_start = JakAndDaxterRegion("Bunny Cave (Start)", player, multiworld, level_name, 10)
-
-    # Includes the cell and 3 orbs at the exit.
-    bunny_cave_end = JakAndDaxterRegion("Bunny Cave (End)", player, multiworld, level_name, 3)
-    bunny_cave_end.add_cell_locations([64])
-
-    switch_cave = JakAndDaxterRegion("Yellow Eco Switch Cave", player, multiworld, level_name, 4)
-    switch_cave.add_cell_locations([60])
-    switch_cave.add_special_locations([60])
-
-    # Only what can be covered by single jump.
-    fort_interior = JakAndDaxterRegion("Fort Interior (Main)", player, multiworld, level_name, 19)
-
-    # Reaching the top of the watch tower, getting the fly with the blue eco, and falling down to get the caches.
-    fort_interior_caches = JakAndDaxterRegion("Fort Interior (Caches)", player, multiworld, level_name, 51)
-    fort_interior_caches.add_fly_locations([196673])
-    fort_interior_caches.add_cache_locations([23348, 23349, 23350])
-
-    # Need higher jump.
-    fort_interior_base = JakAndDaxterRegion("Fort Interior (Base)", player, multiworld, level_name, 0)
-    fort_interior_base.add_fly_locations([262209], access_rule=lambda state:
-                                         state.has("Flut Flut", player)
-                                         or world.can_free_scout_flies(state, player))
-
-    # Need farther jump.
-    fort_interior_course_end = JakAndDaxterRegion("Fort Interior (Course End)", player, multiworld, level_name, 2)
-    fort_interior_course_end.add_cell_locations([62])
-
-    # Wire up the virtual regions first.
-    main_area.connect(blockers, rule=lambda state:
-                      state.has("Flut Flut", player) or can_jump_blockers(state, player))
-    main_area.connect(glacier_lurkers, rule=lambda state:
-                      state.has("Flut Flut", player) or can_fight(state, player))
-
-    # Yes, the only (other) way into the rest of the level requires advanced movement.
-    main_area.connect(snowball_canyon, rule=lambda state: can_cross_long_gap(state, player))
-
-    snowball_canyon.connect(main_area)                              # But you can just jump down and run up the ramp.
-    snowball_canyon.connect(bunny_cave_start)                       # Jump down from the glacier troop cliff.
-    snowball_canyon.connect(fort_exterior)                          # Jump down, to the left of frozen box cave.
-    snowball_canyon.connect(frozen_box_cave, rule=lambda state:     # More advanced movement.
-                            state.has("Flut Flut", player)
-                            or can_cross_long_gap(state, player))
-
-    frozen_box_cave.connect(snowball_canyon, rule=lambda state:                 # Same movement to go back.
-                            state.has("Flut Flut", player)
-                            or can_cross_long_gap(state, player))
-    frozen_box_cave.connect(frozen_box_cave_crates, rule=lambda state:          # YES to get these crates.
-                            state.has_any(("Flut Flut", "Yellow Eco Switch"), player))
-    frozen_box_cave.connect(ice_skating_rink, rule=lambda state:                # Same movement to go forward.
-                            state.has("Flut Flut", player)
-                            or can_cross_long_gap(state, player))
-
-    frozen_box_cave_crates.connect(frozen_box_cave)                             # Semi-virtual region, no moves req'd.
-
-    ice_skating_rink.connect(frozen_box_cave, rule=lambda state:                # Same movement to go back.
-                             state.has("Flut Flut", player)
-                             or can_cross_long_gap(state, player))
-    ice_skating_rink.connect(flut_flut_course, rule=lambda state:               # Duh.
-                             state.has("Flut Flut", player))
-    ice_skating_rink.connect(fort_exterior)                                     # Just slide down the elevator ramp.
-
-    fort_exterior.connect(ice_skating_rink, rule=lambda state:                  # Twin elevators OR scout fly ledge.
-                          state.has("Flut Flut", player)
-                          or can_cross_long_gap(state, player))                    # Both doable with main_gap logic.
-    fort_exterior.connect(snowball_canyon)                                      # Run across bridge.
-    fort_exterior.connect(fort_interior, rule=lambda state:                     # Duh.
-                          state.has("Snowy Fort Gate", player))
-    fort_exterior.connect(bunny_cave_start)                                     # Run across bridge.
-    fort_exterior.connect(switch_cave, rule=lambda state:                       # Yes, blocker jumps work here.
-                          state.has("Flut Flut", player)
-                          or can_jump_blockers(state, player))
-
-    fort_interior.connect(fort_interior_caches, rule=lambda state:              # Just need a little height.
-                          state.has_any(("Double Jump", "Flut Flut"), player)
-                          or state.has_all(("Crouch", "Crouch Jump"), player))
-    fort_interior.connect(fort_interior_base, rule=lambda state:                # Just need a little height.
-                          state.has_any(("Double Jump", "Flut Flut"), player)
-                          or state.has_all(("Crouch", "Crouch Jump"), player))
-    fort_interior.connect(fort_interior_course_end, rule=lambda state:          # Just need a little distance.
-                          state.has_any(("Flut Flut", "Double Jump", "Jump Kick"), player)
-                          or state.has_all(("Punch", "Punch Uppercut"), player))
-
-    flut_flut_course.connect(fort_exterior)                                     # Ride the elevator.
+    flut_flut_course.connect(flut_flut_course_finish)                           # One way only.
+    flut_flut_course_finish.connect(fort_exterior)                              # Ride the elevator.
 
     # Must fight way through cave, but there is also a grab-less ledge we must jump over.
     bunny_cave_start.connect(bunny_cave_end, rule=lambda state:
-                             state.has("Flut Flut", player)
+                             can_free_flut_flut(state, player)
                              or (can_fight(state, player)
                                  and (state.has("Double Jump", player)
                                       or state.has_all(("Crouch", "Crouch Jump"), player))))
@@ -400,6 +239,7 @@ def build_regions_with_flut_flut(level_name: str, world: "JakAndDaxterWorld") ->
     world.level_to_regions[level_name].append(frozen_box_cave_crates)
     world.level_to_regions[level_name].append(ice_skating_rink)
     world.level_to_regions[level_name].append(flut_flut_course)
+    world.level_to_regions[level_name].append(flut_flut_course_finish)
     world.level_to_regions[level_name].append(fort_exterior)
     world.level_to_regions[level_name].append(bunny_cave_start)
     world.level_to_regions[level_name].append(bunny_cave_end)
@@ -408,22 +248,6 @@ def build_regions_with_flut_flut(level_name: str, world: "JakAndDaxterWorld") ->
     world.level_to_regions[level_name].append(fort_interior_caches)
     world.level_to_regions[level_name].append(fort_interior_base)
     world.level_to_regions[level_name].append(fort_interior_course_end)
-
-    # Yes, this is a bit nutty, but this allows us to create alternate ways into SM
-    # without having to change the rest of the regions.
-    if options.snowy_mountain_entrance_climb:
-        slippery_rock = JakAndDaxterRegion("Slippery Rock", player, multiworld, level_name, 0)
-        main_area.connect(slippery_rock, rule=lambda state:
-                          state.has("Double Jump", player)
-                          or state.has_all(("Crouch", "Crouch Jump"), player))
-        slippery_rock.connect(snowball_canyon)
-        world.level_to_regions[level_name].append(slippery_rock)
-
-    if options.boosted_and_extended_uppercuts:
-        boosted_gap = JakAndDaxterRegion("Boosted Gap", player, multiworld, level_name, 0)
-        main_area.connect(boosted_gap, rule=lambda state: state.has_all(("Punch", "Punch Uppercut"), player))
-        boosted_gap.connect(snowball_canyon)
-        world.level_to_regions[level_name].append(boosted_gap)
 
     # If Per-Level Orbsanity is enabled, build the special Orbsanity Region. This is a virtual region always
     # accessible to Main Area. The Locations within are automatically checked when you collect enough orbs.

--- a/worlds/jakanddaxter/regs/snowy_mountain_regions.py
+++ b/worlds/jakanddaxter/regs/snowy_mountain_regions.py
@@ -28,10 +28,9 @@ def build_regions(level_name: str, world: "JakAndDaxterWorld") -> JakAndDaxterRe
     elif options.snowy_mountain_entrance_climb == SnowyMountainEntranceClimb.option_medium:
         # Double Jump or Crouch Jump to slide on the left ledge.
         def can_cross_first_gap(state: CollectionState, p: int) -> bool:
-            return (state.has("Double Jump", p)
+            return (state.has("Double Jump", p) # Includes Double Jump + Jump Kick from default logic.
                     or state.has_all(("Crouch", "Crouch Jump"), p)
                     or state.has_all(("Roll", "Roll Jump"), p)
-                    or state.has_all(("Double Jump", "Jump Kick"), p)
                     or can_do_boosted(state, p))
     else:
         # Cross the gap by jumping over it.
@@ -109,10 +108,10 @@ def build_regions(level_name: str, world: "JakAndDaxterWorld") -> JakAndDaxterRe
     # Flut Flut Course, only reachable when Flut Flut is unlocked.
     flut_flut_course = JakAndDaxterRegion("Flut Flut Course", player, multiworld, level_name, 15)
 
-    # Flut Flut course finish may be reached early with advanced movement, without collecting orbs on the course.
-    flut_flut_course_finish = JakAndDaxterRegion("Flut Flut Course Finish", player, multiworld, level_name, 0)
-    flut_flut_course_finish.add_cell_locations([63])
-    flut_flut_course_finish.add_special_locations([63])
+    # Fort Gate Button may be reached early with advanced movement, without collecting orbs on the course.
+    fort_gate_button = JakAndDaxterRegion("Fort Gate Button", player, multiworld, level_name, 0)
+    fort_gate_button.add_cell_locations([63])
+    fort_gate_button.add_special_locations([63])
 
     # Includes the bridge from snowball_canyon, the area beneath that bridge, and the areas around the fort.
     fort_exterior = JakAndDaxterRegion("Fort Exterior", player, multiworld, level_name, 20)
@@ -198,7 +197,7 @@ def build_regions(level_name: str, world: "JakAndDaxterWorld") -> JakAndDaxterRe
                           or can_free_flut_flut(state, player))
 
     if options.snowy_mountain_flut_flut_skip:
-        fort_exterior.connect(flut_flut_course_finish)                          # Zoom walk down.
+        fort_exterior.connect(fort_gate_button)                          # Zoom walk down.
 
     fort_interior.connect(fort_interior_caches, rule=lambda state:              # Just need a little height.
                           state.has("Double Jump", player)
@@ -213,8 +212,8 @@ def build_regions(level_name: str, world: "JakAndDaxterWorld") -> JakAndDaxterRe
                           or state.has_all(("Punch", "Punch Uppercut"), player)
                           or can_free_flut_flut(state, player))
 
-    flut_flut_course.connect(flut_flut_course_finish)                           # One way only.
-    flut_flut_course_finish.connect(fort_exterior)                              # Ride the elevator.
+    flut_flut_course.connect(fort_gate_button)                           # One way only.
+    fort_gate_button.connect(fort_exterior)                              # Ride the elevator.
 
     # Must fight way through cave, but there is also a grab-less ledge we must jump over.
     bunny_cave_start.connect(bunny_cave_end, rule=lambda state:
@@ -239,7 +238,7 @@ def build_regions(level_name: str, world: "JakAndDaxterWorld") -> JakAndDaxterRe
     world.level_to_regions[level_name].append(frozen_box_cave_crates)
     world.level_to_regions[level_name].append(ice_skating_rink)
     world.level_to_regions[level_name].append(flut_flut_course)
-    world.level_to_regions[level_name].append(flut_flut_course_finish)
+    world.level_to_regions[level_name].append(fort_gate_button)
     world.level_to_regions[level_name].append(fort_exterior)
     world.level_to_regions[level_name].append(bunny_cave_start)
     world.level_to_regions[level_name].append(bunny_cave_end)


### PR DESCRIPTION
This PR refactors the Snowy Mountain region so that it works even with Single Jump entrance climb + Flut Flut escape.

* SnowyMountainEntranceClimb now has 3 options: "Off", "Medium", "Hard". "Medium" is the same as the old toggle, "Hard" includes climbing the entrance with Single Jump only.
* SnowyMountainFlutFlutSkip is a new option which allows reaching the end of the Flut Flut course with only Single Jump, without Flut Flut (but not the orbs on the course)
* I've removed some redundant checks where both the region entrance and the power cell in the region had the same access rules

### Testing

Unit tests all pass, fuzzer with 3000 runs ran for me with no generation failures.

I will run an Archipelago with these changes as well as all changes in #93 in the next few days, and will do some additional manual logic testing after that.

### Additional Notes

This PR will probably have some merge conflicts once #93 has been merged. I still wanted this PR here to be separate so that you can review them independently. I can fix these merge conflicts once the other PR has been merged (but there is no urgency since it's just the option group definitions since I changed them in both PRs).