### PR TITLE
Miscellaneous small changes to advanced movement options

### DIFF
--- a/worlds/jakanddaxter/__init__.py
+++ b/worlds/jakanddaxter/__init__.py
@@ -120,7 +120,7 @@ class JakAndDaxterWebWorld(WebWorld):
             options.AttackWithRollJump,  # Use Roll Jump instead of regular attacks to hit certain targets.
             options.AttacklessLurkerCannons, # Shoot the lurkers with their own cannon.
             options.SentinelBeachAttacklessPelican, # Shoot the Pelican with the cannon.
-        ]),
+        ], True),
         OptionGroup("Tricks & Glitches - Medium", [
             options.PunchUppercutScoutFlies,  # Some may be a little tricky.
             options.GeyserRockCliffClimb, # You have to know where to jump, but the jump is not terribly difficult.
@@ -137,7 +137,7 @@ class JakAndDaxterWebWorld(WebWorld):
             options.BoggySwampPreciseMovement, # Mostly just taking damage on some jumps to get to the next checkpoint.
             options.SnowyMountainEntranceClimb, # Jump onto the wall on the left and simply slide over.
             options.SnowyMountainFlutFlutSkip, # Easily reachable by Zoom Walking.
-        ]),
+        ], True),
         OptionGroup("Tricks & Glitches - Hard", [
             options.BoostedAndExtendedUppercuts,
             options.ForbiddenJungleAttacklessSpiralStumpsScoutFly, # Precise movement from temple to power cell.
@@ -147,7 +147,8 @@ class JakAndDaxterWebWorld(WebWorld):
             options.BoggySwampFlutFlutSkip, # Flut Flut course with only Roll Jump requires precise jumping.
             options.LostPrecursorCitySingleJumpSlideTubeClimb, # Climbing the tube without attacks/moves is hard.
             options.SnowyMountainFlutFlutEscape,  # Escaping is easy, doing the whole level can be tricky though.
-        ]),
+            options.SnowyMountainFortGateSkip, # Getting into the Fort without an open gate is always hard.
+        ], True),
         OptionGroup("Traps", [
             options.FillerPowerCellsReplacedWithTraps,
             options.FillerOrbBundlesReplacedWithTraps,
@@ -551,5 +552,33 @@ class JakAndDaxterWorld(World):
                                             "trap_weights",
                                             "jak_completion_condition",
                                             "require_punch_for_klaww",
+                                            # Tricks & Glitches
+                                            "boosted_and_extended_uppercuts",
+                                            "punch_uppercut_scout_flies",
+                                            "geyser_rock_cliff_climb",
+                                            "sentinel_beach_cannon_tower_climb",
+                                            "snowy_mountain_entrance_climb",
+                                            "boggy_swamp_flut_flut_escape",
+                                            "snowy_mountain_flut_flut_escape",
+                                            "snowy_mountain_flut_flut_skip",
+                                            "sandover_village_cliff_orb_cache_climb",
+                                            "attackless_lurker_cannons",
+                                            "sentinel_beach_attackless_pelican",
+                                            "attack_with_roll_jump",
+                                            "forbidden_jungle_attackless_spiral_stumps_scout_fly",
+                                            "forbidden_jungle_elevator_skip",
+                                            "misty_island_early_far_side_orb_cache",
+                                            "misty_island_attackless_scout_flies",
+                                            "misty_island_arena_fight_skip",
+                                            "misty_island_far_side_cliff_seesaw_skip",
+                                            "rock_village_early_orb_cache",
+                                            "rock_village_pontoon_skip",
+                                            "klaww_cliff_climb",
+                                            "klaww_boulder_skip",
+                                            "boggy_swamp_precise_movement",
+                                            "boggy_swamp_attackless_ambush",
+                                            "boggy_swamp_flut_flut_skip",
+                                            "lost_precursor_city_single_jump_slide_tube_climb",
+                                            "snowy_mountain_fort_gate_skip",
                                             )
         return options_dict

--- a/worlds/jakanddaxter/options.py
+++ b/worlds/jakanddaxter/options.py
@@ -333,6 +333,8 @@ class BoostedAndExtendedUppercuts(Toggle):
 
     Enabling this setting may require Jak to use boosted and extended uppercuts as opposed to regular movement options.
 
+    It may also require Jak to use uneven geometry, or missing collision boxes to reach unintended locations.
+
     This only applies if "Enable Move Randomizer" is ON.
     """
     display_name = "Boosted and Extended Uppercuts"
@@ -632,6 +634,25 @@ class LostPrecursorCitySingleJumpSlideTubeClimb(Toggle):
     display_name = "Lost Precursor City Single Jump Slide Tube Climb"
 
 
+class SnowyMountainFortGateSkip(Choice):
+    """
+    Create an alternative path into the Snowy Mountain Fort Gate without having *Snowy Fort Gate* unlocked.
+
+    Enabling this setting may require Jak to use uneven geometry and precise movement, or *Flut Flut* to enter the Fort
+    in Snowy Mountain.
+
+    **On Foot**: Fort is reachable after many movement options are unlocked.
+
+    **Flut Flut**: Fort is reachable after *Flut Flut* is unlocked.
+    """
+    display_name = "Snowy Mountain Fort Gate Skip"
+
+    option_no = 0
+    option_on_foot = 1
+    option_flut_flut = 2
+    option_both = 3
+
+
 class CompletionCondition(Choice):
     """Set the goal for completing the game."""
     display_name = "Completion Condition"
@@ -688,6 +709,7 @@ class JakAndDaxterOptions(PerGameCommonOptions):
     boggy_swamp_attackless_ambush: BoggySwampAttacklessAmbush
     boggy_swamp_flut_flut_skip: BoggySwampFlutFlutSkip
     lost_precursor_city_single_jump_slide_tube_climb: LostPrecursorCitySingleJumpSlideTubeClimb
+    snowy_mountain_fort_gate_skip: SnowyMountainFortGateSkip
     jak_completion_condition: CompletionCondition
     start_inventory_from_pool: StartInventoryPool
 
@@ -750,5 +772,6 @@ jakanddaxter_option_presets: dict[str, dict[str, Any]] = {
         "boggy_swamp_flut_flut_skip": True,
         "lost_precursor_city_single_jump_slide_tube_climb": True,
         "snowy_mountain_flut_flut_escape": True,
+        "snowy_mountain_fort_gate_skip": SnowyMountainFortGateSkip.option_both,
     }
 }

--- a/worlds/jakanddaxter/regs/forbidden_jungle_regions.py
+++ b/worlds/jakanddaxter/regs/forbidden_jungle_regions.py
@@ -33,6 +33,7 @@ def build_regions(level_name: str, world: "JakAndDaxterWorld") -> tuple[JakAndDa
     river.add_special_locations([5])
     river.add_cache_locations([10369])
 
+    # 12 orbs around temple exit, excluding those directly above (which are in temple_plant_boss_defeated).
     temple_exit = JakAndDaxterRegion("Temple Exit", player, multiworld, level_name, 12)
 
     if options.forbidden_jungle_attackless_spiral_stumps_scout_fly:
@@ -53,8 +54,11 @@ def build_regions(level_name: str, world: "JakAndDaxterWorld") -> tuple[JakAndDa
     temple_int_pre_blue.add_cell_locations([2])
     temple_int_pre_blue.add_special_locations([2])
 
-    temple_int_post_blue = JakAndDaxterRegion("Temple Interior (Post Blue Eco)", player, multiworld, level_name, 39)
-    temple_int_post_blue.add_cell_locations([6], access_rule=lambda state: can_fight(state, player))
+    temple_int_post_blue = JakAndDaxterRegion("Temple Interior (Post Blue Eco)", player, multiworld, level_name, 29)
+
+    # 5 orbs from Plant Boss + 5 orbs from leaving via jump pad. Only reachable when Jak can fight the plant boss.
+    temple_plant_boss_defeated = JakAndDaxterRegion("Temple (Plant Boss defeated)", player, multiworld, level_name, 10)
+    temple_plant_boss_defeated.add_cell_locations([6])
 
     main_area.connect(lurker_machine)               # Run and jump (tree stump platforms).
     main_area.connect(river)                        # Jump down.
@@ -82,11 +86,19 @@ def build_regions(level_name: str, world: "JakAndDaxterWorld") -> tuple[JakAndDa
         # Requires Jungle Elevator.
         temple_exterior.connect(temple_int_pre_blue, rule=lambda state: state.has("Jungle Elevator", player))
 
-    # Requires Blue Eco Switch.
-    temple_int_pre_blue.connect(temple_int_post_blue, rule=lambda state: state.has("Blue Eco Switch", player))
+    if options.boosted_and_extended_uppercuts:
+        # It is possible to reach the boss by jumping through a collision hole above the door.
+        # After defeating the boss, it's possible to go back with blue eco and grab everything (including jump pads).
+        temple_int_pre_blue.connect(temple_int_post_blue, rule=lambda state:
+                                    state.has_all(("Punch", "Punch Uppercut", "Jump Kick"), player)
+                                    or state.has("Blue Eco Switch", player))
+    else:
+        # Requires Blue Eco Switch.
+        temple_int_pre_blue.connect(temple_int_post_blue, rule=lambda state: state.has("Blue Eco Switch", player))
 
     # Requires defeating the plant boss (combat).
-    temple_int_post_blue.connect(temple_exit, rule=lambda state: can_fight(state, player))
+    temple_int_post_blue.connect(temple_plant_boss_defeated, rule=lambda state: can_fight(state, player))
+    temple_plant_boss_defeated.connect(temple_exit)
 
     world.level_to_regions[level_name].append(main_area)
     world.level_to_regions[level_name].append(lurker_machine)
@@ -95,6 +107,7 @@ def build_regions(level_name: str, world: "JakAndDaxterWorld") -> tuple[JakAndDa
     world.level_to_regions[level_name].append(temple_exterior)
     world.level_to_regions[level_name].append(temple_int_pre_blue)
     world.level_to_regions[level_name].append(temple_int_post_blue)
+    world.level_to_regions[level_name].append(temple_plant_boss_defeated)
 
     # If Per-Level Orbsanity is enabled, build the special Orbsanity Region. This is a virtual region always
     # accessible to Main Area. The Locations within are automatically checked when you collect enough orbs.
@@ -111,4 +124,4 @@ def build_regions(level_name: str, world: "JakAndDaxterWorld") -> tuple[JakAndDa
         multiworld.regions.append(orbs)
         main_area.connect(orbs)
 
-    return main_area, temple_int_post_blue
+    return main_area, temple_plant_boss_defeated


### PR DESCRIPTION
This PR contains various small changes bundled together.

- Tricks & Glitches Option Groups are now collapsed per default
- Option values are now in slot data
- FJ temple refactor for unreachable orbs until boss has been defeated
- FJ temple blue eco door skip with boosted/extended uppercuts
- SM Fort Gate skip on foot or via Flut Flut
- SM Flut Flut escape logic fix (it's a bit hard to free Flut Flut if it's not there)

I've added the FJ temple blue eco door skip to the "Boosted/Extended Uppercuts" category as you suggested in the Discord. I've updated the category description to indicate that it also requires knowledge about level geometry, collision boxes, etc. since the way to skip the door is not super intuitive - though I can also add a separate option for this as well.

I've restructured the FJ temple regions as well - I hope the comments in the code explain everything there, but feel free to ask if something seems weird :)


### Testing

I haven't done testing other than the Unit Tests + Fuzzer for this yet (though I have finished an Archipelago with 2x Jak and Daxter with the previous version). I'll try to do some specific logic testing (by giving myself items/moves and looking at locations that are in-logic) soon as well.

However, I do feel like I'm reaching the limit of what I can test as a single person (especially with 27 additional options). If you have any cool tricks on how to test this, then I'm happy to try them out . Otherwise, I'll review the code once more, and play around a bit with some scenarios with all options enabled to see if I can spot anything that's obviously wrong.