### PR TITLE
Advanced movement logic: More categories, more tricks

### DIFF
--- a/worlds/jakanddaxter/__init__.py
+++ b/worlds/jakanddaxter/__init__.py
@@ -127,10 +127,10 @@ class JakAndDaxterWebWorld(WebWorld):
             options.SandoverVillageCliffOrbCacheClimb, # Same here.
             options.SentinelBeachCannonTowerClimb, # Medium with Double Jump, hard with Jump Kick only.
             options.ForbiddenJungleElevatorSkip, # Deload glitch is easy, but hitting the loading zone can be tricky.
-            options.MistyIslandEarlyFarSideOrbCache, # Precise movement, but not too hard.
+            options.MistyIslandSingleJumpFarSideOrbCache, # Precise movement, but not too hard.
             options.MistyIslandArenaFightSkip, # Drop down from top or use cannon to shoot enemies.
             options.MistyIslandFarSideCliffSeesawSkip, # Relatively easy, but route is not obvious.
-            options.RockVillageEarlyOrbCache, # Precise movement, but not too hard, fast retries possible.
+            options.RockVillageSingleJumpOrbCache, # Precise movement, but not too hard, fast retries possible.
             options.RockVillagePontoonSkip, # May require fast swimming, but not too tight.
             options.KlawwCliffClimb, # Easy when out of bounds spot is known.
             options.KlawwBoulderSkip, # Same trick as above.
@@ -140,14 +140,17 @@ class JakAndDaxterWebWorld(WebWorld):
         ], True),
         OptionGroup("Tricks & Glitches - Hard", [
             options.BoostedAndExtendedUppercuts,
+            options.SentinelBeachBlueEcoSwitchSkip, # Precise movement required.
             options.ForbiddenJungleAttacklessSpiralStumpsScoutFly, # Precise movement from temple to power cell.
             options.MistyIslandAttacklessScoutFlies, # Some require relatively precise movement with long runback.
             options.BoggySwampFlutFlutEscape, # Harder trick, long runback.
-            options.BoggySwampAttacklessAmbush, # Doing the lurker ambush without attacks is annoying (and hard).
             options.BoggySwampFlutFlutSkip, # Flut Flut course with only Roll Jump requires precise jumping.
-            options.LostPrecursorCitySingleJumpSlideTubeClimb, # Climbing the tube without attacks/moves is hard.
             options.SnowyMountainFlutFlutEscape,  # Escaping is easy, doing the whole level can be tricky though.
-            options.SnowyMountainFortGateSkip, # Getting into the Fort without an open gate is always hard.
+        ], True),
+        OptionGroup("Tricks & Glitches - Very Hard", [
+            options.BoggySwampAttacklessAmbush,  # Doing the lurker ambush without attacks is annoying (and hard).
+            options.LostPrecursorCitySingleJumpSlideTubeClimb,  # Climbing the tube without attacks/moves is hard.
+            options.SnowyMountainFortGateSkip,  # Getting into the Fort without an open gate is always very hard.
         ], True),
         OptionGroup("Traps", [
             options.FillerPowerCellsReplacedWithTraps,
@@ -260,6 +263,12 @@ class JakAndDaxterWorld(World):
 
     can_free_scout_flies: Callable[[CollectionState, int], bool]
     """Returns true if Jak can break scout fly boxes, depending on the chosen options."""
+
+    can_do_boosted: Callable[[CollectionState, int], bool]
+    """Returns true if Jak can do a boosted, using Punch + Punch Uppercut."""
+
+    can_do_boosted_extended: Callable[[CollectionState, int], bool]
+    """Returns true if Jak can do a boosted, using Punch + Punch Uppercut + Jump Kick."""
 
     total_orbs: int = 2000
     orb_bundle_item_name: str = ""
@@ -567,11 +576,11 @@ class JakAndDaxterWorld(World):
                                             "attack_with_roll_jump",
                                             "forbidden_jungle_attackless_spiral_stumps_scout_fly",
                                             "forbidden_jungle_elevator_skip",
-                                            "misty_island_early_far_side_orb_cache",
+                                            "misty_island_single_jump_far_side_orb_cache",
                                             "misty_island_attackless_scout_flies",
                                             "misty_island_arena_fight_skip",
                                             "misty_island_far_side_cliff_seesaw_skip",
-                                            "rock_village_early_orb_cache",
+                                            "rock_village_single_jump_orb_cache",
                                             "rock_village_pontoon_skip",
                                             "klaww_cliff_climb",
                                             "klaww_boulder_skip",
@@ -580,5 +589,6 @@ class JakAndDaxterWorld(World):
                                             "boggy_swamp_flut_flut_skip",
                                             "lost_precursor_city_single_jump_slide_tube_climb",
                                             "snowy_mountain_fort_gate_skip",
+                                            "sentinel_beach_blue_eco_switch_skip",
                                             )
         return options_dict

--- a/worlds/jakanddaxter/options.py
+++ b/worlds/jakanddaxter/options.py
@@ -496,7 +496,7 @@ class ForbiddenJungleElevatorSkip(Toggle):
     display_name = "Forbidden Jungle Elevator Skip"
 
 
-class MistyIslandEarlyFarSideOrbCache(Toggle):
+class MistyIslandSingleJumpFarSideOrbCache(Toggle):
     """
     Create an alternative path to the Far Side Orb Cache in Misty Island.
 
@@ -504,7 +504,7 @@ class MistyIslandEarlyFarSideOrbCache(Toggle):
 
     This only applies if "Enable Move Randomizer" is ON.
     """
-    display_name = "Misty Island Early Far Side Orb Cache"
+    display_name = "Misty Island Single Jump Far Side Orb Cache"
 
 
 class MistyIslandAttacklessScoutFlies(Toggle):
@@ -544,7 +544,7 @@ class MistyIslandFarSideCliffSeesawSkip(Toggle):
     display_name = "Misty Island Far Side Cliff Seesaw Skip"
 
 
-class RockVillageEarlyOrbCache(Toggle):
+class RockVillageSingleJumpOrbCache(Toggle):
     """
     Remove requirements from the orb cache in Rock Village.
 
@@ -552,7 +552,7 @@ class RockVillageEarlyOrbCache(Toggle):
 
     This only applies if "Enable Move Randomizer" is ON.
     """
-    display_name = "Rock Village Early Orb Cache"
+    display_name = "Rock Village Single Jump Orb Cache"
 
 
 class RockVillagePontoonSkip(Toggle):
@@ -618,7 +618,8 @@ class BoggySwampFlutFlutSkip(Toggle):
     """
     Create an alternative path through the Flut Flut course in Boggy Swamp without having *Flut Flut* unlocked.
 
-    Enabling this setting may require Jak to complete the whole course with only *Roll Jump*.
+    Enabling this setting may require Jak to complete the whole course with only *Roll Jump*, and reach the scout fly
+    "Overlooking Flut Flut" with only *Double Jump* or *Jump Kick*.
     """
     display_name = "Boggy Swamp Flut Flut Skip"
 
@@ -653,6 +654,14 @@ class SnowyMountainFortGateSkip(Choice):
     option_flut_flut = 2
     option_both = 3
 
+class SentinelBeachBlueEcoSwitchSkip(Toggle):
+    """
+    Create an alternative path to the blue eco jump pad in Sentinel Beach without having *Blue Eco Switch* unlocked.
+
+    Enabling this setting may require Jak to use precise movement to reach the jump pad with enough blue eco, using
+    only *Punch* or only *Roll Jump*.
+    """
+    display_name = "Sentinel Beach Blue Eco Switch Skip"
 
 class CompletionCondition(Choice):
     """Set the goal for completing the game."""
@@ -698,11 +707,11 @@ class JakAndDaxterOptions(PerGameCommonOptions):
     attack_with_roll_jump: AttackWithRollJump
     forbidden_jungle_attackless_spiral_stumps_scout_fly: ForbiddenJungleAttacklessSpiralStumpsScoutFly
     forbidden_jungle_elevator_skip: ForbiddenJungleElevatorSkip
-    misty_island_early_far_side_orb_cache: MistyIslandEarlyFarSideOrbCache
+    misty_island_single_jump_far_side_orb_cache: MistyIslandSingleJumpFarSideOrbCache
     misty_island_attackless_scout_flies: MistyIslandAttacklessScoutFlies
     misty_island_arena_fight_skip: MistyIslandArenaFightSkip
     misty_island_far_side_cliff_seesaw_skip: MistyIslandFarSideCliffSeesawSkip
-    rock_village_early_orb_cache: RockVillageEarlyOrbCache
+    rock_village_single_jump_orb_cache: RockVillageSingleJumpOrbCache
     rock_village_pontoon_skip: RockVillagePontoonSkip
     klaww_cliff_climb: KlawwCliffClimb
     klaww_boulder_skip: KlawwBoulderSkip
@@ -711,6 +720,7 @@ class JakAndDaxterOptions(PerGameCommonOptions):
     boggy_swamp_flut_flut_skip: BoggySwampFlutFlutSkip
     lost_precursor_city_single_jump_slide_tube_climb: LostPrecursorCitySingleJumpSlideTubeClimb
     snowy_mountain_fort_gate_skip: SnowyMountainFortGateSkip
+    sentinel_beach_blue_eco_switch_skip: SentinelBeachBlueEcoSwitchSkip
     jak_completion_condition: CompletionCondition
     start_inventory_from_pool: StartInventoryPool
 
@@ -732,10 +742,10 @@ jakanddaxter_option_presets: dict[str, dict[str, Any]] = {
         "sandover_village_cliff_orb_cache_climb": True,
         "sentinel_beach_cannon_tower_climb": SentinelBeachCannonTowerClimb.option_medium,
         "forbidden_jungle_elevator_skip": True,
-        "misty_island_early_far_side_orb_cache": True,
+        "misty_island_single_jump_far_side_orb_cache": True,
         "misty_island_arena_fight_skip": True,
         "misty_island_far_side_cliff_seesaw_skip": True,
-        "rock_village_early_orb_cache": True,
+        "rock_village_single_jump_orb_cache": True,
         "rock_village_pontoon_skip": True,
         "klaww_cliff_climb": True,
         "klaww_boulder_skip": True,
@@ -754,10 +764,10 @@ jakanddaxter_option_presets: dict[str, dict[str, Any]] = {
         "sandover_village_cliff_orb_cache_climb": True,
         "sentinel_beach_cannon_tower_climb": SentinelBeachCannonTowerClimb.option_hard,
         "forbidden_jungle_elevator_skip": True,
-        "misty_island_early_far_side_orb_cache": True,
+        "misty_island_single_jump_far_side_orb_cache": True,
         "misty_island_arena_fight_skip": True,
         "misty_island_far_side_cliff_seesaw_skip": True,
-        "rock_village_early_orb_cache": True,
+        "rock_village_single_jump_orb_cache": True,
         "rock_village_pontoon_skip": True,
         "klaww_cliff_climb": True,
         "klaww_boulder_skip": True,
@@ -766,13 +776,45 @@ jakanddaxter_option_presets: dict[str, dict[str, Any]] = {
         "snowy_mountain_flut_flut_skip": True,
 
         "boosted_and_extended_uppercuts": True,
+        "sentinel_beach_blue_eco_switch_skip": True,
         "forbidden_jungle_attackless_spiral_stumps_scout_fly": True,
         "misty_island_attackless_scout_flies": True,
         "boggy_swamp_flut_flut_escape": True,
-        "boggy_swamp_attackless_ambush": True,
         "boggy_swamp_flut_flut_skip": True,
-        "lost_precursor_city_single_jump_slide_tube_climb": True,
         "snowy_mountain_flut_flut_escape": True,
+    },
+    "Move Randomizer + All Tricks & Glitches": {
+        "enable_move_randomizer": True,
+        "attack_with_roll_jump": True,
+        "attackless_lurker_cannons": True,
+        "sentinel_beach_attackless_pelican": True,
+
+        "punch_uppercut_scout_flies": True,
+        "geyser_rock_cliff_climb": True,
+        "sandover_village_cliff_orb_cache_climb": True,
+        "sentinel_beach_cannon_tower_climb": SentinelBeachCannonTowerClimb.option_hard,
+        "forbidden_jungle_elevator_skip": True,
+        "misty_island_single_jump_far_side_orb_cache": True,
+        "misty_island_arena_fight_skip": True,
+        "misty_island_far_side_cliff_seesaw_skip": True,
+        "rock_village_single_jump_orb_cache": True,
+        "rock_village_pontoon_skip": True,
+        "klaww_cliff_climb": True,
+        "klaww_boulder_skip": True,
+        "boggy_swamp_precise_movement": True,
+        "snowy_mountain_entrance_climb": SnowyMountainEntranceClimb.option_hard,
+        "snowy_mountain_flut_flut_skip": True,
+
+        "boosted_and_extended_uppercuts": True,
+        "sentinel_beach_blue_eco_switch_skip": True,
+        "forbidden_jungle_attackless_spiral_stumps_scout_fly": True,
+        "misty_island_attackless_scout_flies": True,
+        "boggy_swamp_flut_flut_escape": True,
+        "boggy_swamp_flut_flut_skip": True,
+        "snowy_mountain_flut_flut_escape": True,
+
+        "boggy_swamp_attackless_ambush": True,
+        "lost_precursor_city_single_jump_slide_tube_climb": True,
         "snowy_mountain_fort_gate_skip": SnowyMountainFortGateSkip.option_both,
     }
 }

--- a/worlds/jakanddaxter/regs/boggy_swamp_regions.py
+++ b/worlds/jakanddaxter/regs/boggy_swamp_regions.py
@@ -90,9 +90,15 @@ def build_regions(level_name: str, world: "JakAndDaxterWorld") -> JakAndDaxterRe
     # Orbs collectable here with yellow eco and goggles.
     flut_flut_pad = JakAndDaxterRegion("Flut Flut Pad", player, multiworld, level_name, 36)
 
-    flut_flut_course = JakAndDaxterRegion("Flut Flut Course", player, multiworld, level_name, 23)
+    # This region contains the first scout fly + orbs, when going towards the region entrance.
+    early_flut_flut_course = JakAndDaxterRegion("Early Flut Flut Course", player, multiworld, level_name, 6)
+    # This scout fly box can be broken using yellow eco.
+    early_flut_flut_course.add_fly_locations([327723])
+
+    flut_flut_course = JakAndDaxterRegion("Flut Flut Course", player, multiworld, level_name, 17)
     flut_flut_course.add_cell_locations([37])
-    flut_flut_course.add_fly_locations([327723, 131115])
+    # This scout fly box can be broken using yellow eco.
+    flut_flut_course.add_fly_locations([131115])
 
     # Includes some orbs on the way to the cabin, blue+yellow eco to collect.
     farthy_snacks = JakAndDaxterRegion("Farthy's Snacks", player, multiworld, level_name, 7)
@@ -152,29 +158,31 @@ def build_regions(level_name: str, world: "JakAndDaxterWorld") -> JakAndDaxterRe
 
     flut_flut_pad.connect(second_bats)
 
-    if options.boosted_and_extended_uppercuts:
-        if options.boggy_swamp_flut_flut_skip:
-            # Allow both uppercuts and Roll Jump.
-            flut_flut_pad.connect(flut_flut_course, rule=lambda state:
-                                  state.has("Flut Flut", player)
-                                  or state.has_all(("Roll", "Roll Jump"), player)
-                                  or state.has_all(("Punch", "Punch Uppercut", "Jump Kick"), player))
-        else:
-            # Uppercuts only.
-            flut_flut_pad.connect(flut_flut_course, rule=lambda state:
-                                  state.has("Flut Flut", player)
-                                  or state.has_all(("Punch", "Punch Uppercut", "Jump Kick"), player))
-    elif options.boggy_swamp_flut_flut_skip:
-        # Roll Jump only.
+    if options.boggy_swamp_flut_flut_skip:
+        # The course is doable with only Roll Jump, or by using boosteds with Jump Kick.
         flut_flut_pad.connect(flut_flut_course, rule=lambda state:
                               state.has("Flut Flut", player)
-                              or state.has_all(("Roll", "Roll Jump"), player))
+                              or state.has_all(("Roll", "Roll Jump"), player)
+                              or world.can_do_boosted_extended(state, player))
     else:
-        flut_flut_pad.connect(flut_flut_course, rule=lambda state: state.has("Flut Flut", player))  # Naturally.
+        flut_flut_pad.connect(flut_flut_course, rule=lambda state:
+                              state.has("Flut Flut", player)
+                              or world.can_do_boosted_extended(state, player))
+
+    if options.boggy_swamp_flut_flut_skip:
+        # It's possible to reach the early parts by zoom walking with momentum, followed by a Double Jump or Jump Kick.
+        flut_flut_pad.connect(early_flut_flut_course, rule=lambda state:
+                              state.has_any(("Double Jump", "Jump Kick"), player)
+                              or world.can_do_boosted(state, player))
+    else:
+        flut_flut_pad.connect(early_flut_flut_course, rule=lambda state: world.can_do_boosted(state, player))
 
     flut_flut_pad.connect(farthy_snacks)
 
     flut_flut_course.connect(flut_flut_pad)
+    # When Jak can reach the whole Flut Flut course, he can always reach the early parts as well.
+    flut_flut_course.connect(early_flut_flut_course)
+    early_flut_flut_course.connect(flut_flut_pad)
 
     farthy_snacks.connect(flut_flut_pad)
 
@@ -217,6 +225,7 @@ def build_regions(level_name: str, world: "JakAndDaxterWorld") -> JakAndDaxterRe
     world.level_to_regions[level_name].append(third_jump_pad)
     world.level_to_regions[level_name].append(fourth_jump_pad)
     world.level_to_regions[level_name].append(flut_flut_pad)
+    world.level_to_regions[level_name].append(early_flut_flut_course)
     world.level_to_regions[level_name].append(flut_flut_course)
     world.level_to_regions[level_name].append(farthy_snacks)
     world.level_to_regions[level_name].append(box_field)

--- a/worlds/jakanddaxter/regs/forbidden_jungle_regions.py
+++ b/worlds/jakanddaxter/regs/forbidden_jungle_regions.py
@@ -86,15 +86,11 @@ def build_regions(level_name: str, world: "JakAndDaxterWorld") -> tuple[JakAndDa
         # Requires Jungle Elevator.
         temple_exterior.connect(temple_int_pre_blue, rule=lambda state: state.has("Jungle Elevator", player))
 
-    if options.boosted_and_extended_uppercuts:
-        # It is possible to reach the boss by jumping through a collision hole above the door.
-        # After defeating the boss, it's possible to go back with blue eco and grab everything (including jump pads).
-        temple_int_pre_blue.connect(temple_int_post_blue, rule=lambda state:
-                                    state.has_all(("Punch", "Punch Uppercut", "Jump Kick"), player)
-                                    or state.has("Blue Eco Switch", player))
-    else:
-        # Requires Blue Eco Switch.
-        temple_int_pre_blue.connect(temple_int_post_blue, rule=lambda state: state.has("Blue Eco Switch", player))
+    # It is possible to reach the boss by jumping through a collision hole above the door, using boosteds.
+    # After defeating the boss, it's possible to go back with blue eco and grab everything (including jump pads).
+    temple_int_pre_blue.connect(temple_int_post_blue, rule=lambda state:
+                                world.can_do_boosted_extended(state, player)
+                                or state.has("Blue Eco Switch", player))
 
     # Requires defeating the plant boss (combat).
     temple_int_post_blue.connect(temple_plant_boss_defeated, rule=lambda state: can_fight(state, player))

--- a/worlds/jakanddaxter/regs/gol_and_maias_citadel_regions.py
+++ b/worlds/jakanddaxter/regs/gol_and_maias_citadel_regions.py
@@ -16,15 +16,10 @@ def build_regions(level_name: str, world: "JakAndDaxterWorld") -> tuple[JakAndDa
     # This level is full of short-medium gaps that cannot be crossed by single jump alone. If you have the boosted
     # and extended uppercut option on, those moves are added as part of the function definition. We do NOT want to
     # check options IN THE FUNCTION.
-    if options.boosted_and_extended_uppercuts:
-        def can_jump_farther(state: CollectionState, p: int) -> bool:
-            return (state.has_any(("Double Jump", "Jump Kick"), p)
-                    or state.has_all(("Punch", "Punch Uppercut"), p)
-                    or state.has_all(("Roll", "Roll Jump"), p))
-    else:
-        def can_jump_farther(state: CollectionState, p: int) -> bool:
-            return (state.has_any(("Double Jump", "Jump Kick"), p)
-                    or state.has_all(("Roll", "Roll Jump"), p))
+    def can_jump_farther(state: CollectionState, p: int) -> bool:
+        return (state.has_any(("Double Jump", "Jump Kick"), p)
+                or state.has_all(("Roll", "Roll Jump"), p)
+                or world.can_do_boosted(state, player))
 
     def can_jump_stairs(state: CollectionState, p: int) -> bool:
         return (state.has("Double Jump", p)

--- a/worlds/jakanddaxter/regs/misty_island_regions.py
+++ b/worlds/jakanddaxter/regs/misty_island_regions.py
@@ -98,7 +98,7 @@ def build_regions(level_name: str, world: "JakAndDaxterWorld") -> JakAndDaxterRe
                      state.has("Jump Dive", player)
                      or state.has_all(("Crouch", "Crouch Jump"), player))
 
-    if options.misty_island_early_far_side_orb_cache:
+    if options.misty_island_single_jump_far_side_orb_cache:
         # Only if you can break the bone bridges to carry blue eco over the mud pit.
         far_side.connect(far_side_cache, rule=lambda state: can_fight(state, player))
     else:

--- a/worlds/jakanddaxter/regs/rock_village_regions.py
+++ b/worlds/jakanddaxter/regs/rock_village_regions.py
@@ -30,7 +30,7 @@ def build_regions(level_name: str, world: "JakAndDaxterWorld") -> tuple[JakAndDa
 
     orb_cache = JakAndDaxterRegion("Orb Cache", player, multiworld, level_name, 20)
 
-    if options.rock_village_early_orb_cache:
+    if options.rock_village_single_jump_orb_cache:
         # It is possible to just reach the orb cache with blue eco without roll jump.
         orb_cache.add_cache_locations([10945])
     else:
@@ -46,7 +46,7 @@ def build_regions(level_name: str, world: "JakAndDaxterWorld") -> tuple[JakAndDa
 
     klaww_cliff = JakAndDaxterRegion("Klaww's Cliff", player, multiworld, level_name, 0)
 
-    if options.rock_village_early_orb_cache:
+    if options.rock_village_single_jump_orb_cache:
         # It is possible to just reach the orb cache with blue eco without roll jump.
         main_area.connect(orb_cache)
     else:

--- a/worlds/jakanddaxter/regs/sandover_village_regions.py
+++ b/worlds/jakanddaxter/regs/sandover_village_regions.py
@@ -59,15 +59,10 @@ def build_regions(level_name: str, world: "JakAndDaxterWorld") -> JakAndDaxterRe
                       or state.has_all(("Crouch", "Crouch Jump"), player)
                       or state.has_all(("Crouch", "Crouch Uppercut", "Jump Kick"), player))
 
-    if options.boosted_and_extended_uppercuts:
-        main_area.connect(oracle_platforms, rule=lambda state:
-                          state.has_all(("Roll", "Roll Jump"), player)
-                          or state.has_all(("Double Jump", "Jump Kick"), player)
-                          or state.has_all(("Punch", "Punch Uppercut"), player))
-    else:
-        main_area.connect(oracle_platforms, rule=lambda state:
-                          state.has_all(("Roll", "Roll Jump"), player)
-                          or state.has_all(("Double Jump", "Jump Kick"), player))
+    main_area.connect(oracle_platforms, rule=lambda state:
+                      state.has_all(("Roll", "Roll Jump"), player)
+                      or state.has_all(("Double Jump", "Jump Kick"), player)
+                      or world.can_do_boosted(state, player))
 
     # All these can go back to main_area immediately.
     orb_cache_cliff.connect(main_area)

--- a/worlds/jakanddaxter/regs/sentinel_beach_regions.py
+++ b/worlds/jakanddaxter/regs/sentinel_beach_regions.py
@@ -25,17 +25,16 @@ def build_regions(level_name: str, world: "JakAndDaxterWorld") -> JakAndDaxterRe
     def can_reach_cannon(state: CollectionState, p: int) -> bool:
         return state.has("Blue Eco Switch", p) or can_climb_cannon_tower(state, p)
 
-    # There is an open blue eco vent on the rock spires, which will allow you to open all the orb crates on the spires,
-    # the scout fly on "blue ridge", and the scout fly on the sentinel. You can get on the spires one of two ways:
-    # use the locked blue eco vent on the beach, or you can climb the cannon tower and boosted uppercut to the spires.
-    if options.boosted_and_extended_uppercuts:
-        def can_reach_rock_spires(state: CollectionState, p: int) -> bool:
+    def can_reach_blue_eco_vent(state: CollectionState, p: int) -> bool:
+        # It's possible to grab the Blue Eco Vent with an extended boosted after climbing the tower.
+        if options.sentinel_beach_blue_eco_switch_skip:
             return (state.has("Blue Eco Switch", p)
-                    or (can_climb_cannon_tower(state, p)
-                        and state.has_all(("Punch", "Punch Uppercut", "Jump Kick"), p)))
-    else:
-        def can_reach_rock_spires(state: CollectionState, p: int) -> bool:
-            return state.has("Blue Eco Switch", p)
+                    or (can_climb_cannon_tower(state, p) and world.can_do_boosted_extended(state, p))
+                    or state.has("Kick", p)
+                    or state.has_all(("Roll", "Roll Jump"), p))
+        else:
+            return (state.has("Blue Eco Switch", p)
+                    or (can_climb_cannon_tower(state, p) and world.can_do_boosted_extended(state, p)))
 
     main_area = JakAndDaxterRegion("Main Area", player, multiworld, level_name, 128)
     main_area.add_cell_locations([18, 21, 22])
@@ -47,7 +46,7 @@ def build_regions(level_name: str, world: "JakAndDaxterWorld") -> JakAndDaxterRe
     # This scout fly box can be broken with an open blue eco vent (locked one on beach or open one on rock spires),
     # or by normal combat tricks.
     main_area.add_fly_locations([393236], access_rule=lambda state:
-                                can_reach_rock_spires(state, player)
+                                can_reach_blue_eco_vent(state, player)
                                 or world.can_free_scout_flies(state, player))
 
     # No need for the blue eco vent for either of the orb caches.
@@ -76,9 +75,10 @@ def build_regions(level_name: str, world: "JakAndDaxterWorld") -> JakAndDaxterRe
     green_ridge = JakAndDaxterRegion("Ridge Near Green Vents", player, multiworld, level_name, 5)
     green_ridge.add_fly_locations([131092], access_rule=lambda state: world.can_free_scout_flies(state, player))
 
-    # If you can get onto "blue ridge" then there's no way you don't have a move/blue eco to open the scout fly box.
     blue_ridge = JakAndDaxterRegion("Ridge Near Blue Vent", player, multiworld, level_name, 5)
-    blue_ridge.add_fly_locations([196628])
+    blue_ridge.add_fly_locations([196628], access_rule=lambda state:
+                                 can_reach_blue_eco_vent(state, player)
+                                 or world.can_free_scout_flies(state, player))
 
     rock_spires = JakAndDaxterRegion("Rock Spires", player, multiworld, level_name, 12)
 
@@ -107,10 +107,10 @@ def build_regions(level_name: str, world: "JakAndDaxterWorld") -> JakAndDaxterRe
 
     # You can use an open blue eco vent, or you can use the logs, to reach this place.
     main_area.connect(blue_ridge, rule=lambda state:
-                      can_reach_rock_spires(state, player)
+                      can_reach_blue_eco_vent(state, player)
                       or can_uppercut_and_jump_logs(state, player))
 
-    main_area.connect(rock_spires, rule=lambda state: can_reach_rock_spires(state, player))
+    main_area.connect(rock_spires, rule=lambda state: can_reach_blue_eco_vent(state, player))
     rock_spires.connect(cannon_tower)
 
     # An advanced way of reaching the cannon tower without Blue Eco Switch.

--- a/worlds/jakanddaxter/regs/sentinel_beach_regions.py
+++ b/worlds/jakanddaxter/regs/sentinel_beach_regions.py
@@ -25,14 +25,20 @@ def build_regions(level_name: str, world: "JakAndDaxterWorld") -> JakAndDaxterRe
     def can_reach_cannon(state: CollectionState, p: int) -> bool:
         return state.has("Blue Eco Switch", p) or can_climb_cannon_tower(state, p)
 
-    def can_reach_blue_eco_vent(state: CollectionState, p: int) -> bool:
-        # It's possible to grab the Blue Eco Vent with an extended boosted after climbing the tower.
-        if options.sentinel_beach_blue_eco_switch_skip:
+    if options.sentinel_beach_blue_eco_switch_skip:
+        # It's possible to grab the Blue Eco Vent with just Punch or Roll Jump by using an optimized route from the
+        # blue eco to the Flut Flut egg.
+        def can_reach_blue_eco_vent(state: CollectionState, p: int) -> bool:
             return (state.has("Blue Eco Switch", p)
                     or (can_climb_cannon_tower(state, p) and world.can_do_boosted_extended(state, p))
-                    or state.has("Kick", p)
+                    or state.has("Punch", p)
                     or state.has_all(("Roll", "Roll Jump"), p))
-        else:
+    else:
+        # There is an open blue eco vent on the rock spires, which will allow you to open all the orb crates on the spires,
+        # the scout fly on "blue ridge", and the scout fly on the sentinel. You can get on the spires one of two ways:
+        # use the locked blue eco vent on the beach, or you can climb the cannon tower and boosted uppercut to the spires.
+
+        def can_reach_blue_eco_vent(state: CollectionState, p: int) -> bool:
             return (state.has("Blue Eco Switch", p)
                     or (can_climb_cannon_tower(state, p) and world.can_do_boosted_extended(state, p)))
 

--- a/worlds/jakanddaxter/regs/snowy_mountain_regions.py
+++ b/worlds/jakanddaxter/regs/snowy_mountain_regions.py
@@ -14,13 +14,6 @@ def build_regions(level_name: str, world: "JakAndDaxterWorld") -> JakAndDaxterRe
     player = world.player
 
     # First, define helper functions to determine if Jak can actually get anywhere.
-    if options.boosted_and_extended_uppercuts:
-        def can_do_boosted(state: CollectionState, p: int) -> bool:
-            return state.has_all(("Punch", "Punch Uppercut"), p)
-    else:
-        def can_do_boosted(_: CollectionState, __: int) -> bool:
-            return False
-
     if options.snowy_mountain_entrance_climb == SnowyMountainEntranceClimb.option_hard:
         # Single Jump is enough to slide on the left ledge by getting attacked while jumping next to it.
         def can_cross_first_gap(_: CollectionState, __: int) -> bool:
@@ -31,13 +24,13 @@ def build_regions(level_name: str, world: "JakAndDaxterWorld") -> JakAndDaxterRe
             return (state.has("Double Jump", p) # Includes Double Jump + Jump Kick from default logic.
                     or state.has_all(("Crouch", "Crouch Jump"), p)
                     or state.has_all(("Roll", "Roll Jump"), p)
-                    or can_do_boosted(state, p))
+                    or world.can_do_boosted(state, p))
     else:
         # Cross the gap by jumping over it.
         def can_cross_first_gap(state: CollectionState, p: int) -> bool:
             return (state.has_all(("Roll", "Roll Jump"), p)
                     or state.has_all(("Double Jump", "Jump Kick"), p)
-                    or can_do_boosted(state, p))
+                    or world.can_do_boosted(state, p))
 
     # Helper function that returns true if Jak can reach and free Flut Flut.
     # When Flut Flut can be reached, it can reach everything in the whole level.
@@ -51,7 +44,7 @@ def build_regions(level_name: str, world: "JakAndDaxterWorld") -> JakAndDaxterRe
     def can_cross_medium_gap(state: CollectionState, p: int) -> bool:
         return (state.has_any(("Double Jump", "Jump Kick"), p)
                 or state.has_all(("Roll", "Roll Jump"), p)
-                or can_do_boosted(state, p))
+                or world.can_do_boosted(state, p))
 
     def can_jump_blockers(state: CollectionState, p: int) -> bool:
         return (state.has_any(("Double Jump", "Jump Kick"), p)

--- a/worlds/jakanddaxter/rules.py
+++ b/worlds/jakanddaxter/rules.py
@@ -49,6 +49,17 @@ def set_option_driven_rules(world: "JakAndDaxterWorld"):
     else:
         world.can_fight_or_roll_jump = can_fight
 
+    if options.boosted_and_extended_uppercuts:
+        world.can_do_boosted = lambda state, p: (
+            state.has_all(("Punch", "Punch Uppercut"), p)
+        )
+        world.can_do_boosted_extended = lambda state, p: (
+            state.has_all(("Punch", "Punch Uppercut", "Jump Kick"), p)
+        )
+    else:
+        world.can_do_boosted = lambda state, p: False
+        world.can_do_boosted_extended = lambda state, p: False
+
 
 def recalculate_reachable_orbs(state: CollectionState, player: int, world: "JakAndDaxterWorld") -> None:
 


### PR DESCRIPTION
- New "Very Hard" difficulty category
- Some refactoring for boosteds to prevent code duplications
- Rename some options to make them easier to understand
- BS: Flut Flut course is split up into two sections for "Flut Flut skip"
- SB: New "Eco Switch Skip" logic, allowing to reach the switch with just Punch or Roll Jump
- SB: Orbs on the rock spires towards the cannon are now also reachable from the tower with enough movement options