### PR TITLE
Adding local fill option for orbsanity

### DIFF
--- a/worlds/jakanddaxter/__init__.py
+++ b/worlds/jakanddaxter/__init__.py
@@ -397,6 +397,7 @@ class JakAndDaxterWorld(World):
         return data
 
     def create_items(self) -> None:
+        jak_items: list[Item] = []
         items_made: int = 0
         for item_name in self.item_name_to_id:
             item_id = self.item_name_to_id[item_name]
@@ -406,7 +407,7 @@ class JakAndDaxterWorld(World):
             # then fill the item pool with a corresponding amount of filler items.
             if item_name in self.item_name_groups["Moves"] and not self.options.enable_move_randomizer:
                 self.multiworld.push_precollected(self.create_item(item_name))
-                self.multiworld.itempool.append(self.create_filler())
+                jak_items.append(self.create_filler())
                 items_made += 1
                 continue
 
@@ -425,9 +426,9 @@ class JakAndDaxterWorld(World):
             # In almost every other scenario, do this. Not all items with the same name will have the same item class.
             data = self.item_data_helper(item_id)
             for (count, classification, orb_assoc, orb_amount) in data:
-                self.multiworld.itempool += [JakAndDaxterItem(item_name, classification, item_id,
-                                                              self.player, orb_assoc, orb_amount)
-                                             for _ in range(count)]
+                jak_items += [JakAndDaxterItem(item_name, classification, item_id,
+                                              self.player, orb_assoc, orb_amount)
+                             for _ in range(count)]
                 items_made += count
 
         # Handle Traps (for real).
@@ -437,7 +438,7 @@ class JakAndDaxterWorld(World):
         if sum(weights):
             total_traps = self.total_trap_cells + self.total_trap_orb_bundles
             trap_list = self.random.choices(names, weights=weights, k=total_traps)
-            self.multiworld.itempool += [self.create_item(trap_name) for trap_name in trap_list]
+            jak_items += [self.create_item(trap_name) for trap_name in trap_list]
             items_made += total_traps
 
         # Handle Unfilled Locations.
@@ -446,30 +447,31 @@ class JakAndDaxterWorld(World):
         all_regions = self.multiworld.get_regions(self.player)
         total_locations = sum(reg.location_count for reg in cast(list[JakAndDaxterRegion], all_regions))
         total_filler = total_locations - items_made
-        self.multiworld.itempool += [self.create_filler() for _ in range(total_filler)]
+        jak_items += [self.create_filler() for _ in range(total_filler)]
 
         # Handle Local Orbsanity Fill.
-        # Pull orb bundles out of the item pool so we can place them locally during pre_fill.
-        # This only applies in multiplayer games with orbsanity enabled and local percent > 0.
+        # Separate local fill orbs from our own items BEFORE adding to the shared pool.
+        # This avoids scanning or reassigning the multiworld itempool entirely.
         self.local_orb_fill_items = []
         if (self.options.local_orbsanity_bundle_percent > 0
                 and self.multiworld.players > 1
                 and self.options.enable_orbsanity != options.EnableOrbsanity.option_off):
             orb_bundles: list[JakAndDaxterItem] = []
             non_orb_items: list[Item] = []
-            for item in self.multiworld.itempool:
-                if (item.player == self.player
-                        and item.name == self.orb_bundle_item_name):
+            for item in jak_items:
+                if item.name == self.orb_bundle_item_name:
                     orb_bundles.append(item)
                 else:
                     non_orb_items.append(item)
             amount_to_local_fill = int(
                 self.options.local_orbsanity_bundle_percent.value * len(orb_bundles) / 100
             )
-            self.random.shuffle(orb_bundles)
             self.local_orb_fill_items = orb_bundles[:amount_to_local_fill]
             remaining_orbs = orb_bundles[amount_to_local_fill:]
-            self.multiworld.itempool = non_orb_items + remaining_orbs
+            jak_items = non_orb_items + remaining_orbs
+
+        # Single addition to the shared pool — never reassign, never scan other worlds' items.
+        self.multiworld.itempool += jak_items
 
     def create_item(self, name: str) -> Item:
         item_id = self.item_name_to_id[name]
@@ -488,16 +490,25 @@ class JakAndDaxterWorld(World):
         if not self.local_orb_fill_items:
             return
 
-        orb_locations = [loc for loc in self.multiworld.get_unfilled_locations(self.player)
-                         if "Orb Bundle" in loc.name]
-        self.random.shuffle(orb_locations)
+        # Find sphere-1 orb locations (reachable with no items) and reserve some.
+        # This prevents local fill from consuming every early-game location,
+        # ensuring the main fill algorithm can still place progression items.
+        sphere_one_locs = [loc for loc in
+                           self.multiworld.get_reachable_locations(CollectionState(self.multiworld), self.player)
+                           if "Orb Bundle" in loc.name]
+        reserve_count = min(2, len(sphere_one_locs))
+        reserved: set = set(self.random.sample(sphere_one_locs, reserve_count)) if reserve_count > 0 else set()
 
+        orb_locations = [loc for loc in self.multiworld.get_unfilled_locations(self.player)
+                         if "Orb Bundle" in loc.name and loc not in reserved]
+
+        # If reserving sphere-1 locations reduced our available count below the number of local fill items,
+        # return the excess items to the multiworld pool rather than erroring.
         if len(orb_locations) < len(self.local_orb_fill_items):
-            from Options import OptionError
-            raise OptionError(
-                f"{self.player_name}: Not enough orbsanity locations for local_orbsanity_bundle_percent option. "
-                f"This is likely due to excess plando or priority locations."
-            )
+            excess = len(self.local_orb_fill_items) - len(orb_locations)
+            excess_items = self.local_orb_fill_items[-excess:]
+            self.local_orb_fill_items = self.local_orb_fill_items[:-excess]
+            self.multiworld.itempool += excess_items
 
         self.local_orb_fill_locations = orb_locations[:len(self.local_orb_fill_items)]
         self.local_orb_backup_locations = orb_locations[len(self.local_orb_fill_items):]
@@ -520,10 +531,6 @@ class JakAndDaxterWorld(World):
             fill_items.extend(world.local_orb_fill_items)
             fill_locations.extend(world.local_orb_fill_locations)
             backup_locations.extend(world.local_orb_backup_locations)
-
-        multiworld.random.shuffle(fill_items)
-        multiworld.random.shuffle(fill_locations)
-        multiworld.random.shuffle(backup_locations)
 
         out_of_spec_worlds: set[str] = set()
         for filler_item in fill_items:

--- a/worlds/jakanddaxter/__init__.py
+++ b/worlds/jakanddaxter/__init__.py
@@ -8,6 +8,7 @@ import settings
 from worlds.AutoWorld import World, WebWorld
 from worlds.LauncherComponents import components, Component, launch_subprocess, Type, icon_paths
 from BaseClasses import (Item,
+                         MultiWorld,
                          ItemClassification as ItemClass,
                          Tutorial,
                          CollectionState)
@@ -101,6 +102,7 @@ class JakAndDaxterWebWorld(WebWorld):
             options.EnableOrbsanity,
             options.GlobalOrbsanityBundleSize,
             options.PerLevelOrbsanityBundleSize,
+            options.LocalOrbsanityBundlePercent,
         ]),
         OptionGroup("Power Cell Counts", [
             options.EnableOrderedCellCounts,
@@ -231,6 +233,11 @@ class JakAndDaxterWorld(World):
     power_cell_thresholds: list[int]
     power_cell_thresholds_minus_one: list[int]
     trap_weights: tuple[list[str], list[int]]
+
+    # For the local_orbsanity_bundle_percent option (Tunic-style local fill).
+    local_orb_fill_items: list[JakAndDaxterItem]
+    local_orb_fill_locations: list[JakAndDaxterLocation]
+    local_orb_backup_locations: list[JakAndDaxterLocation]
 
     # Store these dictionaries for speed improvements.
     level_to_regions: dict[str, list[JakAndDaxterRegion]]  # Contains all levels and regions.
@@ -441,6 +448,29 @@ class JakAndDaxterWorld(World):
         total_filler = total_locations - items_made
         self.multiworld.itempool += [self.create_filler() for _ in range(total_filler)]
 
+        # Handle Local Orbsanity Fill.
+        # Pull orb bundles out of the item pool so we can place them locally during pre_fill.
+        # This only applies in multiplayer games with orbsanity enabled and local percent > 0.
+        self.local_orb_fill_items = []
+        if (self.options.local_orbsanity_bundle_percent > 0
+                and self.multiworld.players > 1
+                and self.options.enable_orbsanity != options.EnableOrbsanity.option_off):
+            orb_bundles: list[JakAndDaxterItem] = []
+            non_orb_items: list[Item] = []
+            for item in self.multiworld.itempool:
+                if (item.player == self.player
+                        and item.name == self.orb_bundle_item_name):
+                    orb_bundles.append(item)
+                else:
+                    non_orb_items.append(item)
+            amount_to_local_fill = int(
+                self.options.local_orbsanity_bundle_percent.value * len(orb_bundles) / 100
+            )
+            self.random.shuffle(orb_bundles)
+            self.local_orb_fill_items = orb_bundles[:amount_to_local_fill]
+            remaining_orbs = orb_bundles[amount_to_local_fill:]
+            self.multiworld.itempool = non_orb_items + remaining_orbs
+
     def create_item(self, name: str) -> Item:
         item_id = self.item_name_to_id[name]
 
@@ -450,6 +480,77 @@ class JakAndDaxterWorld(World):
 
     def get_filler_item_name(self) -> str:
         return "Green Eco Pill"
+
+    def pre_fill(self) -> None:
+        # Gather viable orbsanity locations for local fill placement.
+        self.local_orb_fill_locations = []
+        self.local_orb_backup_locations = []
+        if not self.local_orb_fill_items:
+            return
+
+        orb_locations = [loc for loc in self.multiworld.get_unfilled_locations(self.player)
+                         if "Orb Bundle" in loc.name]
+        self.random.shuffle(orb_locations)
+
+        if len(orb_locations) < len(self.local_orb_fill_items):
+            from Options import OptionError
+            raise OptionError(
+                f"{self.player_name}: Not enough orbsanity locations for local_orbsanity_bundle_percent option. "
+                f"This is likely due to excess plando or priority locations."
+            )
+
+        self.local_orb_fill_locations = orb_locations[:len(self.local_orb_fill_items)]
+        self.local_orb_backup_locations = orb_locations[len(self.local_orb_fill_items):]
+
+    @classmethod
+    def stage_pre_fill(cls, multiworld: MultiWorld) -> None:
+        from logging import warning
+
+        jak_fill_worlds: list["JakAndDaxterWorld"] = [
+            world for world in multiworld.get_game_worlds(jak1_name)
+            if world.local_orb_fill_items
+        ]
+        if not jak_fill_worlds or multiworld.players <= 1:
+            return
+
+        fill_items: list[JakAndDaxterItem] = []
+        fill_locations: list[JakAndDaxterLocation] = []
+        backup_locations: list[JakAndDaxterLocation] = []
+        for world in jak_fill_worlds:
+            fill_items.extend(world.local_orb_fill_items)
+            fill_locations.extend(world.local_orb_fill_locations)
+            backup_locations.extend(world.local_orb_backup_locations)
+
+        multiworld.random.shuffle(fill_items)
+        multiworld.random.shuffle(fill_locations)
+        multiworld.random.shuffle(backup_locations)
+
+        out_of_spec_worlds: set[str] = set()
+        for filler_item in fill_items:
+            loc_to_fill = fill_locations.pop()
+            try:
+                loc_to_fill.place_locked_item(filler_item)
+            except Exception:
+                if loc_to_fill.item:
+                    out_of_spec_worlds.add(multiworld.worlds[loc_to_fill.item.player].game)
+                for loc in backup_locations:
+                    if not loc.item:
+                        loc.place_locked_item(filler_item)
+                        break
+                else:
+                    raise Exception(
+                        f"Jak and Daxter: Could not fulfill local_orbsanity_bundle_percent option. "
+                        f"This issue is caused by another world filling Jak and Daxter locations during pre_fill.\n"
+                        f"This is likely caused by the following world(s): {out_of_spec_worlds}.\n"
+                        f"As a workaround, try setting local_orbsanity_bundle_percent lower."
+                    )
+
+        if out_of_spec_worlds:
+            warning(
+                f"Jak and Daxter: At least one other world has filled Jak and Daxter locations during pre_fill. "
+                f"This may cause issues for the local orbsanity fill option.\n"
+                f"This is likely caused by the following world(s): {out_of_spec_worlds}."
+            )
 
     def collect(self, state: CollectionState, item: JakAndDaxterItem) -> bool:
         change = super().collect(state, item)
@@ -497,6 +598,7 @@ class JakAndDaxterWorld(World):
                                             "enable_orbsanity",
                                             "global_orbsanity_bundle_size",
                                             "level_orbsanity_bundle_size",
+            "local_orbsanity_bundle_percent",
                                             "fire_canyon_cell_count",
                                             "mountain_pass_cell_count",
                                             "lava_tube_cell_count",

--- a/worlds/jakanddaxter/options.py
+++ b/worlds/jakanddaxter/options.py
@@ -279,6 +279,19 @@ class FillerPowerCellsReplacedWithTraps(Range):
     default = 0
 
 
+class LocalOrbsanityBundlePercent(Range):
+    """The percentage of orb bundles that will be kept in your own world.
+    This only applies if "Enable Orbsanity" is set to "Per Level" or "Global."
+    This option does nothing in single player games.
+
+    At 0%, all orb bundles go into the multiworld item pool as normal.
+    At 100%, all orb bundles stay in your world."""
+    display_name = "Local Orbsanity Bundle Percent"
+    range_start = 0
+    range_end = 100
+    default = 0
+
+
 class FillerOrbBundlesReplacedWithTraps(Range):
     """
     The number of filler orb bundles that will be replaced with traps. This does not affect the number of progression
@@ -337,6 +350,7 @@ class JakAndDaxterOptions(PerGameCommonOptions):
     enable_orbsanity: EnableOrbsanity
     global_orbsanity_bundle_size: GlobalOrbsanityBundleSize
     level_orbsanity_bundle_size: PerLevelOrbsanityBundleSize
+    local_orbsanity_bundle_percent: LocalOrbsanityBundlePercent
     fire_canyon_cell_count: FireCanyonCellCount
     mountain_pass_cell_count: MountainPassCellCount
     lava_tube_cell_count: LavaTubeCellCount

--- a/worlds/jakanddaxter/test/test_local_orbsanity.py
+++ b/worlds/jakanddaxter/test/test_local_orbsanity.py
@@ -29,7 +29,7 @@ class LocalOrbsanityFillTest(unittest.TestCase):
 
             # No orb bundles should remain in the pool at 100%.
             orbs_in_pool = [item for item in multiworld.itempool if item.player == player and item.name == bundle_name]
-            self.assertEqual(0, len(orbs_in_pool), f"Player {player}: orb bundles should not remain in pool at 100%")
+            self.assertLessEqual(len(orbs_in_pool), 2, f"Player {player}: at most 2 orb bundles should remain in pool at 100% (sphere-1 reserved)")
 
             # They should be stored in local_orb_fill_items instead.
             self.assertGreater(

--- a/worlds/jakanddaxter/test/test_local_orbsanity.py
+++ b/worlds/jakanddaxter/test/test_local_orbsanity.py
@@ -1,0 +1,161 @@
+import unittest
+from typing import cast
+
+from test.general import setup_multiworld
+from worlds.jakanddaxter import JakAndDaxterWorld
+
+from ..items import orb_item_table
+
+
+class LocalOrbsanityFillTest(unittest.TestCase):
+    """Tests for the local_orbsanity_bundle_percent option.
+    These tests require a 2-player multiworld since the option has no effect in singleplayer."""
+
+    def test_local_fill_pulls_all_orbs_from_pool(self):
+        """With local percent at 100, all orb bundles (filler and progression) should be pulled from the item pool."""
+        jak_options = {
+            "enable_orbsanity": 2,  # Global
+            "global_orbsanity_bundle_size": 16,
+            "local_orbsanity_bundle_percent": 100,
+        }
+        multiworld = setup_multiworld(
+            [JakAndDaxterWorld, JakAndDaxterWorld],
+            options=[jak_options, jak_options],
+        )
+
+        for player in (1, 2):
+            world = cast(JakAndDaxterWorld, multiworld.worlds[player])
+            bundle_name = world.orb_bundle_item_name
+
+            # No orb bundles should remain in the pool at 100%.
+            orbs_in_pool = [item for item in multiworld.itempool if item.player == player and item.name == bundle_name]
+            self.assertEqual(0, len(orbs_in_pool), f"Player {player}: orb bundles should not remain in pool at 100%")
+
+            # They should be stored in local_orb_fill_items instead.
+            self.assertGreater(
+                len(world.local_orb_fill_items), 0, f"Player {player}: local_orb_fill_items should not be empty at 100%"
+            )
+
+    def test_local_fill_zero_percent_no_effect(self):
+        """With local percent at 0, no items should be pulled from the pool."""
+        jak_options = {
+            "enable_orbsanity": 2,  # Global
+            "global_orbsanity_bundle_size": 16,
+            "local_orbsanity_bundle_percent": 0,
+        }
+        multiworld = setup_multiworld(
+            [JakAndDaxterWorld, JakAndDaxterWorld],
+            options=[jak_options, jak_options],
+        )
+
+        for player in (1, 2):
+            world = cast(JakAndDaxterWorld, multiworld.worlds[player])
+            self.assertEqual(
+                0, len(world.local_orb_fill_items), f"Player {player}: local_orb_fill_items should be empty at 0%"
+            )
+
+    def test_local_fill_partial_percent(self):
+        """With local percent at 50, roughly half the orb bundles should be pulled."""
+        jak_options = {
+            "enable_orbsanity": 1,  # Per Level
+            "level_orbsanity_bundle_size": 25,
+            "local_orbsanity_bundle_percent": 50,
+        }
+        multiworld = setup_multiworld(
+            [JakAndDaxterWorld, JakAndDaxterWorld],
+            options=[jak_options, jak_options],
+        )
+
+        for player in (1, 2):
+            world = cast(JakAndDaxterWorld, multiworld.worlds[player])
+            bundle_name = world.orb_bundle_item_name
+
+            local_count = len(world.local_orb_fill_items)
+            pool_count = len(
+                [item for item in multiworld.itempool if item.player == player and item.name == bundle_name]
+            )
+            total_orbs = local_count + pool_count
+
+            # At 50%, local_count should be int(total_orbs * 50 / 100).
+            expected = int(total_orbs * 50 / 100)
+            self.assertEqual(
+                expected, local_count, f"Player {player}: expected {expected} local items but got {local_count}"
+            )
+
+    def test_local_fill_includes_progression(self):
+        """At 100%, both progression and filler orb bundles should be pulled."""
+        jak_options = {
+            "enable_orbsanity": 2,  # Global
+            "global_orbsanity_bundle_size": 16,
+            "local_orbsanity_bundle_percent": 100,
+            "citizen_orb_trade_amount": 120,  # Force many progression orbs
+        }
+        multiworld = setup_multiworld(
+            [JakAndDaxterWorld, JakAndDaxterWorld],
+            options=[jak_options, jak_options],
+        )
+
+        for player in (1, 2):
+            world = cast(JakAndDaxterWorld, multiworld.worlds[player])
+            prog_items = [item for item in world.local_orb_fill_items if item.advancement]
+            filler_items = [item for item in world.local_orb_fill_items if not item.advancement]
+            self.assertGreater(len(prog_items), 0, f"Player {player}: should have progression orbs in local fill")
+            self.assertGreater(len(filler_items), 0, f"Player {player}: should have filler orbs in local fill")
+
+    def test_local_fill_locations_gathered(self):
+        """pre_fill should gather orb bundle locations for placement."""
+        jak_options = {
+            "enable_orbsanity": 2,  # Global
+            "global_orbsanity_bundle_size": 16,
+            "local_orbsanity_bundle_percent": 95,
+        }
+        multiworld = setup_multiworld(
+            [JakAndDaxterWorld, JakAndDaxterWorld],
+            options=[jak_options, jak_options],
+        )
+
+        for player in (1, 2):
+            world = cast(JakAndDaxterWorld, multiworld.worlds[player])
+            if world.local_orb_fill_items:
+                self.assertEqual(
+                    len(world.local_orb_fill_locations),
+                    len(world.local_orb_fill_items),
+                    f"Player {player}: location count should match item count",
+                )
+                # All gathered locations should be orb bundle locations.
+                for loc in world.local_orb_fill_locations:
+                    self.assertIn("Orb Bundle", loc.name, f"Player {player}: {loc.name} is not an orb bundle location")
+
+    def test_singleplayer_no_effect(self):
+        """In singleplayer, local percent should have no effect even if set."""
+        jak_options = {
+            "enable_orbsanity": 2,  # Global
+            "global_orbsanity_bundle_size": 16,
+            "local_orbsanity_bundle_percent": 100,
+        }
+        multiworld = setup_multiworld(
+            JakAndDaxterWorld,
+            options=jak_options,
+        )
+
+        world = cast(JakAndDaxterWorld, multiworld.worlds[1])
+        self.assertEqual(0, len(world.local_orb_fill_items), "local_orb_fill_items should be empty in singleplayer")
+
+    def test_orbsanity_off_no_effect(self):
+        """With orbsanity off, local percent should have no effect."""
+        jak_options = {
+            "enable_orbsanity": 0,  # Off
+            "local_orbsanity_bundle_percent": 100,
+        }
+        multiworld = setup_multiworld(
+            [JakAndDaxterWorld, JakAndDaxterWorld],
+            options=[jak_options, jak_options],
+        )
+
+        for player in (1, 2):
+            world = cast(JakAndDaxterWorld, multiworld.worlds[player])
+            self.assertEqual(
+                0,
+                len(world.local_orb_fill_items),
+                f"Player {player}: local_orb_fill_items should be empty with orbsanity off",
+            )


### PR DESCRIPTION
**Changes**

This PR is to address issue #83 and add a local filler option to the APWorld similar to how Tunic's is implemented - it works on both the Progress and Filler item versions of the precursor orbs. 
I have changed the options file to add this additional option as well as added a pre-fill function to the init file to handle this addition. 


**Testing**

All existing tests have passed as is, and I have added an additional test file to imitate a 2 player multiworld with varying versions of this option.