### PR TITLE
Advanced movement logic: Final Updates (Really final version) (Copy)

### DIFF
--- a/worlds/jakanddaxter/__init__.py
+++ b/worlds/jakanddaxter/__init__.py
@@ -137,6 +137,7 @@ class JakAndDaxterWebWorld(WebWorld):
             options.BoggySwampPreciseMovement, # Mostly just taking damage on some jumps to get to the next checkpoint.
             options.SnowyMountainEntranceClimb, # Jump onto the wall on the left and simply slide over.
             options.SnowyMountainFlutFlutSkip, # Easily reachable by Zoom Walking.
+            options.CrouchAbuse, # May require some trial & error, but is generally not hard.
         ], True),
         OptionGroup("Tricks & Glitches - Hard", [
             options.BoostedAndExtendedUppercuts,
@@ -264,6 +265,10 @@ class JakAndDaxterWorld(World):
 
     can_free_scout_flies: Callable[[CollectionState, int], bool]
     """Returns true if Jak can break scout fly boxes, depending on the chosen options."""
+
+    can_free_scout_flies_crouch_abuse: Callable[[CollectionState, int], bool]
+    """Returns true if Jak can break scout fly boxes, depending on the chosen options, if the nearby terrain allows
+    Jak to enter the crouching state without crouch unlocked."""
 
     can_do_boosted: Callable[[CollectionState, int], bool]
     """Returns true if Jak can do a boosted, using Punch + Punch Uppercut."""
@@ -591,5 +596,7 @@ class JakAndDaxterWorld(World):
                                             "lost_precursor_city_single_jump_slide_tube_climb",
                                             "snowy_mountain_fort_gate_skip",
                                             "sentinel_beach_blue_eco_switch_skip",
+                                            "zoomer_escape",
+                                            "crouch_abuse",
                                             )
         return options_dict

--- a/worlds/jakanddaxter/__init__.py
+++ b/worlds/jakanddaxter/__init__.py
@@ -597,6 +597,6 @@ class JakAndDaxterWorld(World):
                                             "snowy_mountain_fort_gate_skip",
                                             "sentinel_beach_blue_eco_switch_skip",
                                             "zoomer_escape",
-                                            "crouch_abuse",
+                                            "crouch_trick",
                                             )
         return options_dict

--- a/worlds/jakanddaxter/__init__.py
+++ b/worlds/jakanddaxter/__init__.py
@@ -137,7 +137,7 @@ class JakAndDaxterWebWorld(WebWorld):
             options.BoggySwampPreciseMovement, # Mostly just taking damage on some jumps to get to the next checkpoint.
             options.SnowyMountainEntranceClimb, # Jump onto the wall on the left and simply slide over.
             options.SnowyMountainFlutFlutSkip, # Easily reachable by Zoom Walking.
-            options.CrouchAbuse, # May require some trial & error, but is generally not hard.
+            options.CrouchTrick, # May require some trial & error, but is generally not hard.
         ], True),
         OptionGroup("Tricks & Glitches - Hard", [
             options.BoostedAndExtendedUppercuts,
@@ -266,7 +266,7 @@ class JakAndDaxterWorld(World):
     can_free_scout_flies: Callable[[CollectionState, int], bool]
     """Returns true if Jak can break scout fly boxes, depending on the chosen options."""
 
-    can_free_scout_flies_crouch_abuse: Callable[[CollectionState, int], bool]
+    can_free_scout_flies_crouch_trick: Callable[[CollectionState, int], bool]
     """Returns true if Jak can break scout fly boxes, depending on the chosen options, if the nearby terrain allows
     Jak to enter the crouching state without crouch unlocked."""
 

--- a/worlds/jakanddaxter/__init__.py
+++ b/worlds/jakanddaxter/__init__.py
@@ -120,6 +120,7 @@ class JakAndDaxterWebWorld(WebWorld):
             options.AttackWithRollJump,  # Use Roll Jump instead of regular attacks to hit certain targets.
             options.AttacklessLurkerCannons, # Shoot the lurkers with their own cannon.
             options.SentinelBeachAttacklessPelican, # Shoot the Pelican with the cannon.
+            options.RockVillagePontoonSkip,  # May require fast swimming, but not too tight.
         ], True),
         OptionGroup("Tricks & Glitches - Medium", [
             options.PunchUppercutScoutFlies,  # Some may be a little tricky.
@@ -131,7 +132,6 @@ class JakAndDaxterWebWorld(WebWorld):
             options.MistyIslandArenaFightSkip, # Drop down from top or use cannon to shoot enemies.
             options.MistyIslandFarSideCliffSeesawSkip, # Relatively easy, but route is not obvious.
             options.RockVillageSingleJumpOrbCache, # Precise movement, but not too hard, fast retries possible.
-            options.RockVillagePontoonSkip, # May require fast swimming, but not too tight.
             options.KlawwCliffClimb, # Easy when out of bounds spot is known.
             options.KlawwBoulderSkip, # Same trick as above.
             options.BoggySwampPreciseMovement, # Mostly just taking damage on some jumps to get to the next checkpoint.
@@ -140,7 +140,6 @@ class JakAndDaxterWebWorld(WebWorld):
         ], True),
         OptionGroup("Tricks & Glitches - Hard", [
             options.BoostedAndExtendedUppercuts,
-            options.SentinelBeachBlueEcoSwitchSkip, # Precise movement required.
             options.ForbiddenJungleAttacklessSpiralStumpsScoutFly, # Precise movement from temple to power cell.
             options.MistyIslandAttacklessScoutFlies, # Some require relatively precise movement with long runback.
             options.BoggySwampFlutFlutEscape, # Harder trick, long runback.
@@ -148,9 +147,11 @@ class JakAndDaxterWebWorld(WebWorld):
             options.SnowyMountainFlutFlutEscape,  # Escaping is easy, doing the whole level can be tricky though.
         ], True),
         OptionGroup("Tricks & Glitches - Very Hard", [
+            options.SentinelBeachBlueEcoSwitchSkip,  # Precise movement required.
             options.BoggySwampAttacklessAmbush,  # Doing the lurker ambush without attacks is annoying (and hard).
             options.LostPrecursorCitySingleJumpSlideTubeClimb,  # Climbing the tube without attacks/moves is hard.
             options.SnowyMountainFortGateSkip,  # Getting into the Fort without an open gate is always very hard.
+            options.ZoomerEscape, # Getting the zoomer out of the intended areas require precise jumps.
         ], True),
         OptionGroup("Traps", [
             options.FillerPowerCellsReplacedWithTraps,

--- a/worlds/jakanddaxter/options.py
+++ b/worlds/jakanddaxter/options.py
@@ -509,7 +509,7 @@ class MistyIslandSingleJumpFarSideOrbCache(Toggle):
 
 class MistyIslandAttacklessScoutFlies(Toggle):
     """
-    Remove attack requirements to the scout flies "Barrel Ramps", "Ledge Near Arena Entrance", "Near Arena Door",
+    Remove attack requirements from the scout flies "Barrel Ramps", "Ledge Near Arena Entrance", "Near Arena Door",
     "Overlooking Entrance" in Misty Island.
 
     Enabling this setting may require Jak to break these scout fly boxes with precise blue eco movement or clever use
@@ -546,7 +546,7 @@ class MistyIslandFarSideCliffSeesawSkip(Toggle):
 
 class RockVillageSingleJumpOrbCache(Toggle):
     """
-    Remove requirements from the orb cache in Rock Village.
+    Remove requirements from the orb cache logic in Rock Village.
 
     Enabling this setting may require Jak to use precise movement to reach the orb cache with only *Single Jump*.
 
@@ -605,7 +605,7 @@ class BoggySwampPreciseMovement(Toggle):
 
 class BoggySwampAttacklessAmbush(Toggle):
     """
-    Remove the attack requirement from the Boggy Swamp ambush.
+    Remove the attack requirement from the Boggy Swamp ambush logic.
 
     Enabling this setting may require Jak to defeat the lurkers by only shooting yellow Eco through his goggles.
 
@@ -654,6 +654,7 @@ class SnowyMountainFortGateSkip(Choice):
     option_flut_flut = 2
     option_both = 3
 
+
 class SentinelBeachBlueEcoSwitchSkip(Toggle):
     """
     Create an alternative path to the blue eco jump pad in Sentinel Beach without having *Blue Eco Switch* unlocked.
@@ -662,6 +663,7 @@ class SentinelBeachBlueEcoSwitchSkip(Toggle):
     only *Punch* or only *Roll Jump*.
     """
     display_name = "Sentinel Beach Blue Eco Switch Skip"
+
 
 class ZoomerEscape(Choice):
     """
@@ -683,6 +685,16 @@ class ZoomerEscape(Choice):
     option_precursor_basin = 2
     option_both = 3
 
+
+class CrouchAbuse(Toggle):
+    """
+    Enabling this setting may require Jak to use uneven terrain to enter the "crouching" state without *Crouch* unlocked.
+    This allows Jak to destroy certain scout fly boxes and reach some additional places with only *Crouch Jump* or
+    only *Crouch Uppercut* unlocked.
+
+    This only applies if "Enable Move Randomizer" is ON.
+    """
+    display_name = "Crouch Abuse"
 
 
 class CompletionCondition(Choice):
@@ -744,6 +756,7 @@ class JakAndDaxterOptions(PerGameCommonOptions):
     snowy_mountain_fort_gate_skip: SnowyMountainFortGateSkip
     sentinel_beach_blue_eco_switch_skip: SentinelBeachBlueEcoSwitchSkip
     zoomer_escape: ZoomerEscape
+    crouch_abuse: CrouchAbuse
     jak_completion_condition: CompletionCondition
     start_inventory_from_pool: StartInventoryPool
 
@@ -776,6 +789,7 @@ jakanddaxter_option_presets: dict[str, dict[str, Any]] = {
         "boggy_swamp_precise_movement": True,
         "snowy_mountain_entrance_climb": SnowyMountainEntranceClimb.option_medium,
         "snowy_mountain_flut_flut_skip": True,
+        "crouch_abuse": True,
     },
     "Move Randomizer + Hard Tricks & Glitches": {
         "enable_move_randomizer": True,
@@ -798,6 +812,7 @@ jakanddaxter_option_presets: dict[str, dict[str, Any]] = {
         "boggy_swamp_precise_movement": True,
         "snowy_mountain_entrance_climb": SnowyMountainEntranceClimb.option_hard,
         "snowy_mountain_flut_flut_skip": True,
+        "crouch_abuse": True,
 
         "boosted_and_extended_uppercuts": True,
         "forbidden_jungle_attackless_spiral_stumps_scout_fly": True,
@@ -827,6 +842,7 @@ jakanddaxter_option_presets: dict[str, dict[str, Any]] = {
         "boggy_swamp_precise_movement": True,
         "snowy_mountain_entrance_climb": SnowyMountainEntranceClimb.option_hard,
         "snowy_mountain_flut_flut_skip": True,
+        "crouch_abuse": True,
 
         "boosted_and_extended_uppercuts": True,
         "forbidden_jungle_attackless_spiral_stumps_scout_fly": True,

--- a/worlds/jakanddaxter/options.py
+++ b/worlds/jakanddaxter/options.py
@@ -789,7 +789,7 @@ jakanddaxter_option_presets: dict[str, dict[str, Any]] = {
         "boggy_swamp_precise_movement": True,
         "snowy_mountain_entrance_climb": SnowyMountainEntranceClimb.option_medium,
         "snowy_mountain_flut_flut_skip": True,
-        "crouch_abuse": True,
+        "crouch_trick": True,
     },
     "Move Randomizer + Hard Tricks & Glitches": {
         "enable_move_randomizer": True,
@@ -812,7 +812,7 @@ jakanddaxter_option_presets: dict[str, dict[str, Any]] = {
         "boggy_swamp_precise_movement": True,
         "snowy_mountain_entrance_climb": SnowyMountainEntranceClimb.option_hard,
         "snowy_mountain_flut_flut_skip": True,
-        "crouch_abuse": True,
+        "crouch_trick": True,
 
         "boosted_and_extended_uppercuts": True,
         "forbidden_jungle_attackless_spiral_stumps_scout_fly": True,
@@ -842,7 +842,7 @@ jakanddaxter_option_presets: dict[str, dict[str, Any]] = {
         "boggy_swamp_precise_movement": True,
         "snowy_mountain_entrance_climb": SnowyMountainEntranceClimb.option_hard,
         "snowy_mountain_flut_flut_skip": True,
-        "crouch_abuse": True,
+        "crouch_trick": True,
 
         "boosted_and_extended_uppercuts": True,
         "forbidden_jungle_attackless_spiral_stumps_scout_fly": True,

--- a/worlds/jakanddaxter/options.py
+++ b/worlds/jakanddaxter/options.py
@@ -686,7 +686,7 @@ class ZoomerEscape(Choice):
     option_both = 3
 
 
-class CrouchAbuse(Toggle):
+class CrouchTrick(Toggle):
     """
     Enabling this setting may require Jak to use uneven terrain to enter the "crouching" state without *Crouch* unlocked.
     This allows Jak to destroy certain scout fly boxes and reach some additional places with only *Crouch Jump* or
@@ -694,7 +694,7 @@ class CrouchAbuse(Toggle):
 
     This only applies if "Enable Move Randomizer" is ON.
     """
-    display_name = "Crouch Abuse"
+    display_name = "Crouch Trick"
 
 
 class CompletionCondition(Choice):
@@ -756,7 +756,7 @@ class JakAndDaxterOptions(PerGameCommonOptions):
     snowy_mountain_fort_gate_skip: SnowyMountainFortGateSkip
     sentinel_beach_blue_eco_switch_skip: SentinelBeachBlueEcoSwitchSkip
     zoomer_escape: ZoomerEscape
-    crouch_abuse: CrouchAbuse
+    crouch_trick: CrouchTrick
     jak_completion_condition: CompletionCondition
     start_inventory_from_pool: StartInventoryPool
 

--- a/worlds/jakanddaxter/options.py
+++ b/worlds/jakanddaxter/options.py
@@ -643,7 +643,7 @@ class SnowyMountainFortGateSkip(Choice):
     Enabling this setting may require Jak to use uneven geometry and precise movement, or *Flut Flut* to enter the Fort
     in Snowy Mountain.
 
-    **On Foot**: Fort is reachable after many movement options are unlocked.
+    **On Foot**: Fort is reachable with only *Jump Kick* and either *Double Jump* or *Crouch Jump*.
 
     **Flut Flut**: Fort is reachable after *Flut Flut* is unlocked.
     """
@@ -662,6 +662,28 @@ class SentinelBeachBlueEcoSwitchSkip(Toggle):
     only *Punch* or only *Roll Jump*.
     """
     display_name = "Sentinel Beach Blue Eco Switch Skip"
+
+class ZoomerEscape(Choice):
+    """
+    Create an alternative way to collect certain scout fly boxes.
+
+    Enabling this setting may require Jak to get a zoomer out of the intended area to collect scout fly boxes without
+    any moves.
+
+    **Misty Island**: Scout Fly On Ship.
+
+    **Precursor Basin**: All nearby scout fly boxes in Rock Village.
+
+    This only applies if "Enable Move Randomizer" is ON.
+    """
+    display_name = "Zoomer Escape"
+
+    option_no = 0
+    option_misty_island = 1
+    option_precursor_basin = 2
+    option_both = 3
+
+
 
 class CompletionCondition(Choice):
     """Set the goal for completing the game."""
@@ -721,6 +743,7 @@ class JakAndDaxterOptions(PerGameCommonOptions):
     lost_precursor_city_single_jump_slide_tube_climb: LostPrecursorCitySingleJumpSlideTubeClimb
     snowy_mountain_fort_gate_skip: SnowyMountainFortGateSkip
     sentinel_beach_blue_eco_switch_skip: SentinelBeachBlueEcoSwitchSkip
+    zoomer_escape: ZoomerEscape
     jak_completion_condition: CompletionCondition
     start_inventory_from_pool: StartInventoryPool
 
@@ -730,12 +753,14 @@ jakanddaxter_option_presets: dict[str, dict[str, Any]] = {
         "attack_with_roll_jump": True,
         "attackless_lurker_cannons": True,
         "sentinel_beach_attackless_pelican": True,
+        "rock_village_pontoon_skip": True,
     },
     "Move Randomizer + Medium Tricks & Glitches": {
         "enable_move_randomizer": True,
         "attack_with_roll_jump": True,
         "attackless_lurker_cannons": True,
         "sentinel_beach_attackless_pelican": True,
+        "rock_village_pontoon_skip": True,
 
         "punch_uppercut_scout_flies": True,
         "geyser_rock_cliff_climb": True,
@@ -746,7 +771,6 @@ jakanddaxter_option_presets: dict[str, dict[str, Any]] = {
         "misty_island_arena_fight_skip": True,
         "misty_island_far_side_cliff_seesaw_skip": True,
         "rock_village_single_jump_orb_cache": True,
-        "rock_village_pontoon_skip": True,
         "klaww_cliff_climb": True,
         "klaww_boulder_skip": True,
         "boggy_swamp_precise_movement": True,
@@ -758,6 +782,7 @@ jakanddaxter_option_presets: dict[str, dict[str, Any]] = {
         "attack_with_roll_jump": True,
         "attackless_lurker_cannons": True,
         "sentinel_beach_attackless_pelican": True,
+        "rock_village_pontoon_skip": True,
 
         "punch_uppercut_scout_flies": True,
         "geyser_rock_cliff_climb": True,
@@ -768,7 +793,6 @@ jakanddaxter_option_presets: dict[str, dict[str, Any]] = {
         "misty_island_arena_fight_skip": True,
         "misty_island_far_side_cliff_seesaw_skip": True,
         "rock_village_single_jump_orb_cache": True,
-        "rock_village_pontoon_skip": True,
         "klaww_cliff_climb": True,
         "klaww_boulder_skip": True,
         "boggy_swamp_precise_movement": True,
@@ -776,7 +800,6 @@ jakanddaxter_option_presets: dict[str, dict[str, Any]] = {
         "snowy_mountain_flut_flut_skip": True,
 
         "boosted_and_extended_uppercuts": True,
-        "sentinel_beach_blue_eco_switch_skip": True,
         "forbidden_jungle_attackless_spiral_stumps_scout_fly": True,
         "misty_island_attackless_scout_flies": True,
         "boggy_swamp_flut_flut_escape": True,
@@ -788,6 +811,7 @@ jakanddaxter_option_presets: dict[str, dict[str, Any]] = {
         "attack_with_roll_jump": True,
         "attackless_lurker_cannons": True,
         "sentinel_beach_attackless_pelican": True,
+        "rock_village_pontoon_skip": True,
 
         "punch_uppercut_scout_flies": True,
         "geyser_rock_cliff_climb": True,
@@ -798,7 +822,6 @@ jakanddaxter_option_presets: dict[str, dict[str, Any]] = {
         "misty_island_arena_fight_skip": True,
         "misty_island_far_side_cliff_seesaw_skip": True,
         "rock_village_single_jump_orb_cache": True,
-        "rock_village_pontoon_skip": True,
         "klaww_cliff_climb": True,
         "klaww_boulder_skip": True,
         "boggy_swamp_precise_movement": True,
@@ -806,15 +829,16 @@ jakanddaxter_option_presets: dict[str, dict[str, Any]] = {
         "snowy_mountain_flut_flut_skip": True,
 
         "boosted_and_extended_uppercuts": True,
-        "sentinel_beach_blue_eco_switch_skip": True,
         "forbidden_jungle_attackless_spiral_stumps_scout_fly": True,
         "misty_island_attackless_scout_flies": True,
         "boggy_swamp_flut_flut_escape": True,
         "boggy_swamp_flut_flut_skip": True,
         "snowy_mountain_flut_flut_escape": True,
 
+        "sentinel_beach_blue_eco_switch_skip": True,
         "boggy_swamp_attackless_ambush": True,
         "lost_precursor_city_single_jump_slide_tube_climb": True,
         "snowy_mountain_fort_gate_skip": SnowyMountainFortGateSkip.option_both,
+        "zoomer_escape": ZoomerEscape.option_both,
     }
 }

--- a/worlds/jakanddaxter/regs/gol_and_maias_citadel_regions.py
+++ b/worlds/jakanddaxter/regs/gol_and_maias_citadel_regions.py
@@ -27,7 +27,8 @@ def build_regions(level_name: str, world: "JakAndDaxterWorld") -> tuple[JakAndDa
                 or state.has_all(("Crouch", "Crouch Uppercut"), p))
 
     main_area = JakAndDaxterRegion("Main Area", player, multiworld, level_name, 0)
-    main_area.add_fly_locations([91], access_rule=lambda state: world.can_free_scout_flies(state, player))
+    # Crouch trick by going back through the entrance door, then jump against the wall.
+    main_area.add_fly_locations([91], access_rule=lambda state: world.can_free_scout_flies_crouch_trick(state, player))
 
     robot_scaffolding = JakAndDaxterRegion("Scaffolding Around Robot", player, multiworld, level_name, 3)
     robot_scaffolding.add_fly_locations([196699], access_rule=lambda state: world.can_free_scout_flies(state, player))
@@ -51,7 +52,8 @@ def build_regions(level_name: str, world: "JakAndDaxterWorld") -> tuple[JakAndDa
 
     # Does not include the orbs in the U turn itself, those belong to bunny room.
     u_turn_room = JakAndDaxterRegion("U-Turn Room", player, multiworld, level_name, 0)
-    u_turn_room.add_fly_locations([262235], access_rule=lambda state: world.can_free_scout_flies(state, player))
+    # Crouch trick by jumping against the glowing wall.
+    u_turn_room.add_fly_locations([262235], access_rule=lambda state: world.can_free_scout_flies_crouch_trick(state, player))
 
     bunny_room = JakAndDaxterRegion("Bunny Chamber", player, multiworld, level_name, 45)
     bunny_room.add_cell_locations([72], access_rule=lambda state: can_fight(state, player))

--- a/worlds/jakanddaxter/regs/lost_precursor_city_regions.py
+++ b/worlds/jakanddaxter/regs/lost_precursor_city_regions.py
@@ -36,7 +36,8 @@ def build_regions(level_name: str, world: "JakAndDaxterWorld") -> JakAndDaxterRe
     second_room.add_fly_locations([49, 65585], access_rule=lambda state: state.has("Jump Dive", player))
 
     # This is the scout fly on the way to the pipe cell, requires normal breaking moves.
-    second_room.add_fly_locations([196657], access_rule=lambda state: world.can_free_scout_flies(state, player))
+    # Crouch trick can be done on the moving block next to it (by sliding down crouched when it retracts).
+    second_room.add_fly_locations([196657], access_rule=lambda state: world.can_free_scout_flies_crouch_trick(state, player))
 
     # This orb vent and scout fly are right next to each other, can be gotten with blue eco and the floating platforms.
     second_room.add_fly_locations([393265])

--- a/worlds/jakanddaxter/regs/misty_island_regions.py
+++ b/worlds/jakanddaxter/regs/misty_island_regions.py
@@ -38,7 +38,7 @@ def build_regions(level_name: str, world: "JakAndDaxterWorld") -> JakAndDaxterRe
 
     # In order to even reach this fly, you must use the seesaw or crouch jump.
     far_side_cliff = JakAndDaxterRegion("Far Side Cliff", player, multiworld, level_name, 5)
-    far_side_cliff.add_fly_locations([28], access_rule=lambda state: world.can_free_scout_flies(state, player))
+    far_side_cliff.add_fly_locations([28], access_rule=lambda state: world.can_free_scout_flies_crouch_trick(state, player))
 
     # To carry the blue eco fast enough to open this cache, you need to break the bone bridges along the way.
     far_side_cache = JakAndDaxterRegion("Far Side Orb Cache", player, multiworld, level_name, 15)
@@ -66,7 +66,7 @@ def build_regions(level_name: str, world: "JakAndDaxterWorld") -> JakAndDaxterRe
         upper_approach.add_fly_locations([65564, 262172])
     else:
         upper_approach.add_fly_locations([65564, 262172], access_rule=lambda state:
-                                         world.can_free_scout_flies(state, player))
+                                         world.can_free_scout_flies_crouch_trick(state, player))
 
     lower_approach = JakAndDaxterRegion("Lower Arena Approach", player, multiworld, level_name, 7)
     lower_approach.add_cell_locations([30])

--- a/worlds/jakanddaxter/regs/misty_island_regions.py
+++ b/worlds/jakanddaxter/regs/misty_island_regions.py
@@ -1,5 +1,5 @@
 from .region_base import JakAndDaxterRegion
-from ..options import EnableOrbsanity
+from ..options import EnableOrbsanity, ZoomerEscape
 from typing import TYPE_CHECKING
 if TYPE_CHECKING:
     from .. import JakAndDaxterWorld
@@ -27,7 +27,12 @@ def build_regions(level_name: str, world: "JakAndDaxterWorld") -> JakAndDaxterRe
 
     ship = JakAndDaxterRegion("Ship", player, multiworld, level_name, 10)
     ship.add_cell_locations([24])
-    ship.add_fly_locations([131100], access_rule=lambda state: world.can_free_scout_flies(state, player))
+
+    if options.zoomer_escape == ZoomerEscape.option_misty_island or options.zoomer_escape == ZoomerEscape.option_both:
+        # It is possible to collect this cell by getting the zoomer out of the lake by making some precise jumps.
+        ship.add_fly_locations([131100])
+    else:
+        ship.add_fly_locations([131100], access_rule=lambda state: world.can_free_scout_flies(state, player))
 
     far_side = JakAndDaxterRegion("Far Side", player, multiworld, level_name, 16)
 

--- a/worlds/jakanddaxter/regs/rock_village_regions.py
+++ b/worlds/jakanddaxter/regs/rock_village_regions.py
@@ -28,10 +28,10 @@ def build_regions(level_name: str, world: "JakAndDaxterWorld") -> tuple[JakAndDa
         # It is possible to get the zoomer out of PB to collect these scout fly boxes.
         main_area.add_fly_locations([131148, 65612, 327756])
         main_area.add_fly_locations([76], access_rule=lambda state:
-                                    world.can_free_scout_flies(state, player))
+                                    world.can_free_scout_flies_crouch_trick(state, player))
     else:
         main_area.add_fly_locations([76, 131148, 65612, 327756], access_rule=lambda state:
-                                    world.can_free_scout_flies(state, player))
+                                    world.can_free_scout_flies_crouch_trick(state, player))
 
     # Warrior Pontoon check. You just talk to him and get his introduction.
     main_area.add_special_locations([33])

--- a/worlds/jakanddaxter/regs/rock_village_regions.py
+++ b/worlds/jakanddaxter/regs/rock_village_regions.py
@@ -1,5 +1,5 @@
 from .region_base import JakAndDaxterRegion
-from ..options import EnableOrbsanity
+from ..options import EnableOrbsanity, ZoomerEscape
 from typing import TYPE_CHECKING
 if TYPE_CHECKING:
     from .. import JakAndDaxterWorld
@@ -22,8 +22,16 @@ def build_regions(level_name: str, world: "JakAndDaxterWorld") -> tuple[JakAndDa
 
     # These 2 scout fly boxes can be broken by running with nearby blue eco.
     main_area.add_fly_locations([196684, 262220])
-    main_area.add_fly_locations([76, 131148, 65612, 327756], access_rule=lambda state:
-                                world.can_free_scout_flies(state, player))
+
+
+    if options.zoomer_escape == ZoomerEscape.option_misty_island or options.zoomer_escape == ZoomerEscape.option_both:
+        # It is possible to get the zoomer out of PB to collect these scout fly boxes.
+        main_area.add_fly_locations([131148, 65612, 327756])
+        main_area.add_fly_locations([76], access_rule=lambda state:
+                                    world.can_free_scout_flies(state, player))
+    else:
+        main_area.add_fly_locations([76, 131148, 65612, 327756], access_rule=lambda state:
+                                    world.can_free_scout_flies(state, player))
 
     # Warrior Pontoon check. You just talk to him and get his introduction.
     main_area.add_special_locations([33])

--- a/worlds/jakanddaxter/regs/sandover_village_regions.py
+++ b/worlds/jakanddaxter/regs/sandover_village_regions.py
@@ -29,7 +29,7 @@ def build_regions(level_name: str, world: "JakAndDaxterWorld") -> JakAndDaxterRe
         main_area.add_fly_locations([196683], access_rule=lambda state:
                                     state.has("Double Jump", player)
                                     or state.has_all(("Crouch", "Crouch Jump"), player)
-                                    or world.can_free_scout_flies(state, player))
+                                    or world.can_free_scout_flies_crouch_abuse(state, player))
 
     orb_cache_cliff = JakAndDaxterRegion("Orb Cache Cliff", player, multiworld, level_name, 15)
     orb_cache_cliff.add_cache_locations([10344])
@@ -43,7 +43,7 @@ def build_regions(level_name: str, world: "JakAndDaxterWorld") -> JakAndDaxterRe
     oracle_platforms.add_cell_locations([14], access_rule=lambda state:
                                         world.can_trade(state, world.total_trade_orbs, 13))
     oracle_platforms.add_fly_locations([393291], access_rule=lambda state:
-                                       world.can_free_scout_flies(state, player))
+                                       world.can_free_scout_flies_crouch_abuse(state, player))
 
     if options.sandover_village_cliff_orb_cache_climb:
         # It is possible to reach this cliff (and the blue Eco next to it) with a single jump
@@ -54,10 +54,16 @@ def build_regions(level_name: str, world: "JakAndDaxterWorld") -> JakAndDaxterRe
                           or state.has_all(("Crouch", "Crouch Jump"), player)
                           or state.has_all(("Crouch", "Crouch Uppercut", "Jump Kick"), player))
 
-    main_area.connect(yakow_cliff, rule=lambda state:
-                      state.has("Double Jump", player)
-                      or state.has_all(("Crouch", "Crouch Jump"), player)
-                      or state.has_all(("Crouch", "Crouch Uppercut", "Jump Kick"), player))
+    if options.crouch_abuse:
+        main_area.connect(yakow_cliff, rule=lambda state:
+                          state.has("Double Jump", player)
+                          or state.has("Crouch Jump", player)
+                          or state.has_all(("Crouch Uppercut", "Jump Kick"), player))
+    else:
+        main_area.connect(yakow_cliff, rule=lambda state:
+                          state.has("Double Jump", player)
+                          or state.has_all(("Crouch", "Crouch Jump"), player)
+                          or state.has_all(("Crouch", "Crouch Uppercut", "Jump Kick"), player))
 
     main_area.connect(oracle_platforms, rule=lambda state:
                       state.has_all(("Roll", "Roll Jump"), player)

--- a/worlds/jakanddaxter/regs/sandover_village_regions.py
+++ b/worlds/jakanddaxter/regs/sandover_village_regions.py
@@ -29,7 +29,7 @@ def build_regions(level_name: str, world: "JakAndDaxterWorld") -> JakAndDaxterRe
         main_area.add_fly_locations([196683], access_rule=lambda state:
                                     state.has("Double Jump", player)
                                     or state.has_all(("Crouch", "Crouch Jump"), player)
-                                    or world.can_free_scout_flies_crouch_abuse(state, player))
+                                    or world.can_free_scout_flies_crouch_trick(state, player))
 
     orb_cache_cliff = JakAndDaxterRegion("Orb Cache Cliff", player, multiworld, level_name, 15)
     orb_cache_cliff.add_cache_locations([10344])
@@ -43,7 +43,7 @@ def build_regions(level_name: str, world: "JakAndDaxterWorld") -> JakAndDaxterRe
     oracle_platforms.add_cell_locations([14], access_rule=lambda state:
                                         world.can_trade(state, world.total_trade_orbs, 13))
     oracle_platforms.add_fly_locations([393291], access_rule=lambda state:
-                                       world.can_free_scout_flies_crouch_abuse(state, player))
+                                       world.can_free_scout_flies_crouch_trick(state, player))
 
     if options.sandover_village_cliff_orb_cache_climb:
         # It is possible to reach this cliff (and the blue Eco next to it) with a single jump
@@ -54,7 +54,7 @@ def build_regions(level_name: str, world: "JakAndDaxterWorld") -> JakAndDaxterRe
                           or state.has_all(("Crouch", "Crouch Jump"), player)
                           or state.has_all(("Crouch", "Crouch Uppercut", "Jump Kick"), player))
 
-    if options.crouch_abuse:
+    if options.crouch_trick:
         main_area.connect(yakow_cliff, rule=lambda state:
                           state.has("Double Jump", player)
                           or state.has("Crouch Jump", player)

--- a/worlds/jakanddaxter/regs/sentinel_beach_regions.py
+++ b/worlds/jakanddaxter/regs/sentinel_beach_regions.py
@@ -53,7 +53,7 @@ def build_regions(level_name: str, world: "JakAndDaxterWorld") -> JakAndDaxterRe
     # or by normal combat tricks.
     main_area.add_fly_locations([393236], access_rule=lambda state:
                                 can_reach_blue_eco_vent(state, player)
-                                or world.can_free_scout_flies(state, player))
+                                or world.can_free_scout_flies_crouch_abuse(state, player))
 
     # No need for the blue eco vent for either of the orb caches.
     main_area.add_cache_locations([12634, 12635])
@@ -79,7 +79,8 @@ def build_regions(level_name: str, world: "JakAndDaxterWorld") -> JakAndDaxterRe
     eco_harvesters.add_cell_locations([15], access_rule=lambda state: world.can_fight_or_roll_jump(state, player))
 
     green_ridge = JakAndDaxterRegion("Ridge Near Green Vents", player, multiworld, level_name, 5)
-    green_ridge.add_fly_locations([131092], access_rule=lambda state: world.can_free_scout_flies(state, player))
+    green_ridge.add_fly_locations([131092], access_rule=lambda state:
+                                  world.can_free_scout_flies_crouch_abuse(state, player))
 
     blue_ridge = JakAndDaxterRegion("Ridge Near Blue Vent", player, multiworld, level_name, 5)
     blue_ridge.add_fly_locations([196628], access_rule=lambda state:
@@ -100,10 +101,16 @@ def build_regions(level_name: str, world: "JakAndDaxterWorld") -> JakAndDaxterRe
     main_area.connect(eco_harvesters)    # Run.
 
     # We need a helper function for the uppercut logs.
-    def can_uppercut_and_jump_logs(state: CollectionState, p: int) -> bool:
-        return (state.has_any(("Double Jump", "Jump Kick"), p)
-                and (state.has_all(("Crouch", "Crouch Uppercut"), p)
-                     or state.has_all(("Punch", "Punch Uppercut"), p)))
+    if options.crouch_abuse:
+        def can_uppercut_and_jump_logs(state: CollectionState, p: int) -> bool:
+            return (state.has_any(("Double Jump", "Jump Kick"), p)
+                    and (state.has("Crouch Uppercut", p) # It's possible to enter crouch state nearby.
+                         or state.has_all(("Punch", "Punch Uppercut"), p)))
+    else:
+        def can_uppercut_and_jump_logs(state: CollectionState, p: int) -> bool:
+            return (state.has_any(("Double Jump", "Jump Kick"), p)
+                    and (state.has_all(("Crouch", "Crouch Uppercut"), p)
+                         or state.has_all(("Punch", "Punch Uppercut"), p)))
 
     # If you have double jump or crouch jump, you don't need the logs to reach this place.
     main_area.connect(green_ridge, rule=lambda state:

--- a/worlds/jakanddaxter/regs/sentinel_beach_regions.py
+++ b/worlds/jakanddaxter/regs/sentinel_beach_regions.py
@@ -53,7 +53,7 @@ def build_regions(level_name: str, world: "JakAndDaxterWorld") -> JakAndDaxterRe
     # or by normal combat tricks.
     main_area.add_fly_locations([393236], access_rule=lambda state:
                                 can_reach_blue_eco_vent(state, player)
-                                or world.can_free_scout_flies_crouch_abuse(state, player))
+                                or world.can_free_scout_flies_crouch_trick(state, player))
 
     # No need for the blue eco vent for either of the orb caches.
     main_area.add_cache_locations([12634, 12635])
@@ -80,7 +80,7 @@ def build_regions(level_name: str, world: "JakAndDaxterWorld") -> JakAndDaxterRe
 
     green_ridge = JakAndDaxterRegion("Ridge Near Green Vents", player, multiworld, level_name, 5)
     green_ridge.add_fly_locations([131092], access_rule=lambda state:
-                                  world.can_free_scout_flies_crouch_abuse(state, player))
+                                  world.can_free_scout_flies_crouch_trick(state, player))
 
     blue_ridge = JakAndDaxterRegion("Ridge Near Blue Vent", player, multiworld, level_name, 5)
     blue_ridge.add_fly_locations([196628], access_rule=lambda state:
@@ -101,7 +101,7 @@ def build_regions(level_name: str, world: "JakAndDaxterWorld") -> JakAndDaxterRe
     main_area.connect(eco_harvesters)    # Run.
 
     # We need a helper function for the uppercut logs.
-    if options.crouch_abuse:
+    if options.crouch_trick:
         def can_uppercut_and_jump_logs(state: CollectionState, p: int) -> bool:
             return (state.has_any(("Double Jump", "Jump Kick"), p)
                     and (state.has("Crouch Uppercut", p) # It's possible to enter crouch state nearby.

--- a/worlds/jakanddaxter/regs/sentinel_beach_regions.py
+++ b/worlds/jakanddaxter/regs/sentinel_beach_regions.py
@@ -113,10 +113,18 @@ def build_regions(level_name: str, world: "JakAndDaxterWorld") -> JakAndDaxterRe
                          or state.has_all(("Punch", "Punch Uppercut"), p)))
 
     # If you have double jump or crouch jump, you don't need the logs to reach this place.
-    main_area.connect(green_ridge, rule=lambda state:
-                      state.has("Double Jump", player)
-                      or state.has_all(("Crouch", "Crouch Jump"), player)
-                      or can_uppercut_and_jump_logs(state, player))
+    if options.crouch_trick:
+        main_area.connect(green_ridge, rule=lambda state:
+                          state.has("Double Jump", player)
+                          # It's possible to enter crouched state by jumping against the edge of the next higher
+                          # eco harvester platform.
+                          or state.has("Crouch Jump", player)
+                          or can_uppercut_and_jump_logs(state, player))
+    else:
+        main_area.connect(green_ridge, rule=lambda state:
+                          state.has("Double Jump", player)
+                          or state.has_all(("Crouch", "Crouch Jump"), player)
+                          or can_uppercut_and_jump_logs(state, player))
 
     # You can use an open blue eco vent, or you can use the logs, to reach this place.
     main_area.connect(blue_ridge, rule=lambda state:

--- a/worlds/jakanddaxter/regs/snowy_mountain_regions.py
+++ b/worlds/jakanddaxter/regs/snowy_mountain_regions.py
@@ -189,7 +189,8 @@ def build_regions(level_name: str, world: "JakAndDaxterWorld") -> JakAndDaxterRe
     # Enter Fort on foot.
     if has_both_gate_skips or gate_skip_option == SnowyMountainFortGateSkip.option_on_foot:
         def can_enter_fort_on_foot(state: CollectionState, p: int) -> bool:
-            return state.has_all(("Crouch", "Crouch Jump", "Jump Kick", "Double Jump", "Punch", "Punch Uppercut"), p)
+            return (state.has("Jump Kick", player)
+                    and (state.has("Double Jump", p) or state.has_all(("Crouch", "Crouch Jump"), p)))
     else:
         def can_enter_fort_on_foot(_: CollectionState, __: int) -> bool:
             return False

--- a/worlds/jakanddaxter/regs/snowy_mountain_regions.py
+++ b/worlds/jakanddaxter/regs/snowy_mountain_regions.py
@@ -108,9 +108,19 @@ def build_regions(level_name: str, world: "JakAndDaxterWorld") -> JakAndDaxterRe
 
     # Includes the bridge from snowball_canyon, the area beneath that bridge, and the areas around the fort.
     fort_exterior = JakAndDaxterRegion("Fort Exterior", player, multiworld, level_name, 20)
-    fort_exterior.add_fly_locations([65601, 393281], access_rule=lambda state:
+
+    # It is technically possible to crouch trick under the bridge - but with endlessly respawning enemies and a long
+    # way that's too annoying to practically do.
+    fort_exterior.add_fly_locations([393281], access_rule=lambda state:
                                     world.can_free_scout_flies(state, player)
                                     or can_free_flut_flut(state, player))
+
+    # However, the scout fly near the YES cave has a crate right next to it that's ideal to use the crouch trick.
+    # The checkpoint is also right next to it, so it's also possible to just get lucky with enemy spawns.
+    fort_exterior.add_fly_locations([65601], access_rule=lambda state:
+                                    world.can_free_scout_flies_crouch_trick(state, player)
+                                    or can_free_flut_flut(state, player))
+
 
     # Includes the icy island and bridge outside the cave entrance.
     bunny_cave_start = JakAndDaxterRegion("Bunny Cave (Start)", player, multiworld, level_name, 10)
@@ -133,8 +143,10 @@ def build_regions(level_name: str, world: "JakAndDaxterWorld") -> JakAndDaxterRe
 
     # Need higher jump.
     fort_interior_base = JakAndDaxterRegion("Fort Interior (Base)", player, multiworld, level_name, 0)
+
+    # It's possible to crouch trick by jumping against the crate that contains green eco pills.
     fort_interior_base.add_fly_locations([262209], access_rule=lambda state:
-                                         world.can_free_scout_flies(state, player)
+                                         world.can_free_scout_flies_crouch_trick(state, player)
                                          or can_free_flut_flut(state, player))
 
     # Need farther jump.

--- a/worlds/jakanddaxter/regs/volcanic_crater_regions.py
+++ b/worlds/jakanddaxter/regs/volcanic_crater_regions.py
@@ -26,8 +26,12 @@ def build_regions(level_name: str, world: "JakAndDaxterWorld") -> JakAndDaxterRe
     main_area.add_cell_locations([74])
 
     # No blue eco sources in this area, all boxes must be broken by hand (yellow eco can't be carried far enough).
-    main_area.add_fly_locations(scouts.locVC_scoutTable.keys(), access_rule=lambda state:
-                                world.can_free_scout_flies(state, player))
+    main_area.add_fly_locations([393293, 196685, 131149, 77, 65613, 327757],
+                                access_rule=lambda state: world.can_free_scout_flies(state, player))
+
+    # Scout fly in miner's cave has sloped terrain nearby. All other scout flies are on island without sloped terrain.
+    main_area.add_fly_locations([262221],
+                                access_rule=lambda state: world.can_free_scout_flies_crouch_trick(state, player))
 
     # Approach the gondola to get this check.
     main_area.add_special_locations([105])

--- a/worlds/jakanddaxter/rules.py
+++ b/worlds/jakanddaxter/rules.py
@@ -42,6 +42,13 @@ def set_option_driven_rules(world: "JakAndDaxterWorld"):
             state.has("Jump Dive", p)
             or state.has_all(("Crouch", "Crouch Uppercut"), p))
 
+    if options.crouch_abuse:
+        world.can_free_scout_flies_crouch_abuse = lambda state, p: (
+            world.can_free_scout_flies(state, p) or state.has("Crouch Uppercut", p)
+        )
+    else:
+        world.can_free_scout_flies_crouch_abuse = world.can_free_scout_flies
+
     if options.attack_with_roll_jump:
         world.can_fight_or_roll_jump = lambda state, p: (
             can_fight(state, p)

--- a/worlds/jakanddaxter/rules.py
+++ b/worlds/jakanddaxter/rules.py
@@ -42,12 +42,12 @@ def set_option_driven_rules(world: "JakAndDaxterWorld"):
             state.has("Jump Dive", p)
             or state.has_all(("Crouch", "Crouch Uppercut"), p))
 
-    if options.crouch_abuse:
-        world.can_free_scout_flies_crouch_abuse = lambda state, p: (
+    if options.crouch_trick:
+        world.can_free_scout_flies_crouch_trick = lambda state, p: (
             world.can_free_scout_flies(state, p) or state.has("Crouch Uppercut", p)
         )
     else:
-        world.can_free_scout_flies_crouch_abuse = world.can_free_scout_flies
+        world.can_free_scout_flies_crouch_trick = world.can_free_scout_flies
 
     if options.attack_with_roll_jump:
         world.can_fight_or_roll_jump = lambda state, p: (


### PR DESCRIPTION
Some difficulty rebalancing, and two new tricks for the (maybe?) final update to finish the "advanced movement logic" project after 7 months :)

## New Tricks
* Added "Crouch Trick" to "Medium"
  * Jumping against a surface where Jak slides down while holding the "Crouch" button allows Jak to enter the "crouched" state without having it unlocked.
  * This mainly allows destroying certain scout fly boxes with Crouch Uppercut (and no Crouch unlocked)
  * Some places can be reached with a Crouch Jump (and no Crouch unlocked)
* Added "Zoomer Escape" to "Very Hard"
  * Separate options for MI and PB
  * MI: Get the scout fly on the ship by jumping with the zoomer
  * PB: Get out of basin with the zoomer to escape nearby scout flies (that are collectible before getting too far away, causing the game to crash)

## Rebalancing
* RV: Pontoon Skip was moved from "Medium" -> "Easy"
* SB: Blue Eco Switch Skip was moved from "Hard" -> "Very Hard"
* SM: Fort Gate Skip now only requires Jump Kick and either Double Jump or Crouch Jump